### PR TITLE
fix(ios): keyboard auto up

### DIFF
--- a/lib/app/modules/home/views/home_view.dart
+++ b/lib/app/modules/home/views/home_view.dart
@@ -77,6 +77,11 @@ class HomeView extends GetView<HomeController> {
           physics: NeverScrollableScrollPhysics(),
 
           onPageChanged: (index) {
+
+            // fix ios keyboard auto up
+            var currentFocus = FocusScope.of(context);
+            currentFocus.unfocus();
+
             homeview.changeCurrentBarIndex(index);
           },
         ),


### PR DESCRIPTION
造成原因: 打开搜索页面搜索之后 `input` 自动 `focus`了, 而且它还是 `AutomaticKeepAliveClientMixin` 的(保留了状态)

https://user-images.githubusercontent.com/45585937/170685548-a0782f72-6c6c-4b4d-87d4-c6580375de4e.MP4
