### PR TITLE
规范化更新发布版本流程

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,12 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
           channel: "stable"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - run: |
           bash script/fetch_git_info.sh
+          node script/draft-release-notes.js > release-notes.txt
           flutter pub get
           flutter pub run build_runner build
           flutter pub deps
@@ -128,8 +132,9 @@ jobs:
           name: windows
 
       # build/ios/iphoneos/app.ipa
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@v2
         with:
+          body_path: release-notes.txt
           files: |
             build/app/outputs/flutter-apk/*.apk
             build/macos/Build/Products/Release/yoyo.mac.zip

--- a/docs/PR.md
+++ b/docs/PR.md
@@ -1,0 +1,18 @@
+# changelog
+
+请在必要的 commit 内编写 changelog, 参照格式:
+
+```sh
+fix: miss codegen type
+
+This is change
+
+Release Notes:
+- 这修复了 codegen 部分
+```
+
+对应的也可以添加 tag 也可以传递 -m
+
+```sh
+git tag v1.0 -m "好雨知时节"
+```

--- a/script/draft-release-notes.js
+++ b/script/draft-release-notes.js
@@ -1,0 +1,63 @@
+const execSync = require('child_process').execSync
+
+const noteReg = /Release Notes:([\s\S]+)/
+
+// git show format spec: https://git-scm.com/docs/git-show#_pretty_formats
+/** @param {string} hash */
+function getCommitBody(hash) {
+  const body = execSync(`git show ${hash} --stat=0 --no-patch --format="%b"`).toString('utf-8').trim()
+  return body
+}
+
+/**
+ * @param {string} body
+ * @returns {string[] | null}
+ */
+function parseCommitBody(body) {
+  if (!body) return null
+  const cx = body.match(noteReg)
+  if (!cx) return null
+  const [ , notes ] = cx
+  if (!notes) return null
+  /** @type {string[]} */
+  const result = notes.trim().split("\n").map(item=> {
+    const _ = item.trim()
+    if (!_.startsWith("-")) return null
+    return _.replace(/^- /, "")
+  }).filter(Boolean)
+  if (!result.length) return null
+  return result
+}
+
+function getTwoTagCommitHashs(a, b) {
+  return execSync(`git log --oneline --format="%h" ${a}...${b}`).toString('utf-8').trim().split("\n")
+}
+
+function getLatestTags(size = 2) {
+  return execSync(`git tag -l --sort=-v:refname | head -${size}`).toString('utf-8').trim().split("\n")
+}
+
+function getTagNote(tag) {
+  const _ = execSync(`git show ${tag} --stat=0 --no-patch --format="%N"`).toString('utf-8').trim()
+  const note = _.split("\n").filter(item=> { return !!item.trim() })
+  // 第一行第二行不需要
+  note.shift()
+  note.shift()
+  return note.join("\n") + "\n"
+}
+
+;(async()=> {
+  const tags = getLatestTags() 
+  const hashs = getTwoTagCommitHashs(tags[0], tags[1])
+  let notes = []
+  for (const hash of hashs) {
+    const body = getCommitBody(hash)
+    const _ = parseCommitBody(body)
+    if (_) {
+      notes = [...notes, ..._]
+    }
+  }
+  let releaseNote = getTagNote(tags[0])
+  releaseNote += notes.join("\n")
+  console.log(releaseNote)
+})()


### PR DESCRIPTION
让我们引入真正的版本更新流程吧

- [x] 之后的 commit 都需要规范化
- [x] 在创建 tag 之后,  附带的 changelog 应该从上面规范中拿到(Github Action)
- ~~[ ] 对应的 hombrew-tap 应该更新~~

例:

```gitcommit
fix: miss codegen type

This is change

Release Notes:
- 这修复了 codegen 部分
```

对应的也可以添加 tag 也可以传递 `-m`

```sh
git tag v1.0 -m "好雨知时节"
```