### PR TITLE
Patch: support custom danmu with webview

### DIFF
--- a/lib/app/modules/play/controllers/play_controller.dart
+++ b/lib/app/modules/play/controllers/play_controller.dart
@@ -168,7 +168,10 @@ class PlayController extends GetxController {
     var type = getSettingAsKeyIdent<IWebPlayerEmbeddedType>(
       SettingsAllKey.webviewPlayType,
     );
-    var url = webPlayerEmbedded.generatePlayerUrl(type, m3u8);
+    // TODO: support custom danmu api
+    var danmu = "https://api.danmu.icu/?ac=dm&url=";
+    var url = webPlayerEmbedded.generatePlayerUrl(type, m3u8, danmu: danmu);
+    debugPrint("url is $url");
     return url;
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -749,10 +749,10 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a"
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "2.0.0"
   modal_bottom_sheet:
     dependency: "direct main"
     description:
@@ -1433,8 +1433,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: HEAD
-      resolved-ref: "630a7c78cbb54f35edf84537d0d8b5fbd42ac3bb"
+      ref: "87c023f5cb94a6e37627b060ba0bd4599b8c738a"
+      resolved-ref: "87c023f5cb94a6e37627b060ba0bd4599b8c738a"
       url: "https://github.com/d1y/webplayer_embedded"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,7 +73,9 @@ dependencies:
       branch: d1y
       ref: c9cf207fccd07ecaa6de0f7ea898046ffa26ff3a
   webplayer_embedded:
-    git: https://github.com/d1y/webplayer_embedded
+    git:
+      url: https://github.com/d1y/webplayer_embedded
+      ref: 87c023f5cb94a6e37627b060ba0bd4599b8c738a
   bitsdojo_window:
     git:
       url: https://github.com/bitsdojo/bitsdojo_window


### PR DESCRIPTION
- [ ] 修改上游的 [d1y/webplayer_embedded](https://github.com/d1y/webplayer_embedded), 使其可以自定义 (https://github.com/d1y/webplayer_embedded/commit/87c023f5cb94a6e37627b060ba0bd4599b8c738a)

<img width="467" alt="image" src="https://github.com/user-attachments/assets/e3dfd221-ef41-494c-9f41-b00a69524518" />

参考:
- https://jy4k.netlify.app
- https://doc.dandanplay.com/open
