### PR TITLE
Patch: add simple DLNA support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
     <application
         android:label="小猫影视"

--- a/lib/app/modules/play/views/cast_screen.dart
+++ b/lib/app/modules/play/views/cast_screen.dart
@@ -1,0 +1,202 @@
+import 'dart:ui';
+
+import 'package:dlna_dart/dlna.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+Map<String, DLNADevice> cacheDeviceList = {};
+
+class CastScreen extends StatefulWidget {
+  const CastScreen({
+    super.key,
+    required this.onTapDevice,
+  });
+
+  final ValueChanged<DLNADevice> onTapDevice;
+
+  @override
+  State<CastScreen> createState() => _CastScreenState();
+}
+
+class _CastScreenState extends State<CastScreen> {
+  late DLNAManager searcher;
+  late final DeviceManager m;
+  Map<String, DLNADevice> deviceList = {};
+
+  Future<void> init() async {
+    m = await searcher.start();
+    m.devices.stream.listen((dlist) {
+      dlist.forEach((key, value) {
+        cacheDeviceList[key] = value;
+      });
+      setState(() {
+        deviceList = cacheDeviceList;
+      });
+    });
+    await _pullToRefresh();
+  }
+
+  Future _pullToRefresh() async {
+    m.deviceList.forEach((key, value) {
+      cacheDeviceList[key] = value;
+    });
+    setState(() {
+      deviceList = cacheDeviceList;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    searcher = DLNAManager();
+    init();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    searcher.stop();
+  }
+
+  Widget buildItem(String uri, DLNADevice device) {
+    var textColor = context.isDarkMode ? Colors.white : Colors.black;
+    final title = device.info.friendlyName;
+    final subtitle = '$uri\r\n${device.info.deviceType}';
+    final s = subtitle.toLowerCase();
+    var icon = Icons.wifi;
+    final support = s.contains("mediarenderer") ||
+        s.contains("avtransport") ||
+        s.contains('mediaserver');
+    if (!support) {
+      icon = Icons.router;
+    }
+    final card = Card(
+      shape: RoundedRectangleBorder(
+        side: BorderSide(
+          color: context.isDarkMode
+              ? Colors.grey
+              : Colors.grey.withValues(alpha: .12),
+          width: .42,
+        ),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      margin: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      elevation: .24,
+      child: Row(
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.only(top: 16, left: 16, bottom: 30),
+            child: CircleAvatar(child: Icon(icon)),
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Container(
+                  margin: const EdgeInsets.only(left: 16),
+                  child: Text(
+                    title,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                      color: textColor,
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 8, left: 16, right: 16),
+                  child: Row(
+                    children: <Widget>[
+                      Expanded(
+                        child: Text(
+                          subtitle,
+                          softWrap: false,
+                          maxLines: 2,
+                          overflow: TextOverflow.fade,
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: textColor,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () {
+          widget.onTapDevice(device);
+        },
+        child: card,
+      ),
+    );
+  }
+
+  Widget _body() {
+    if (deviceList.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    final List<Widget> dlist = [];
+    deviceList.forEach((uri, devi) {
+      dlist.add(buildItem(uri, devi));
+    });
+
+    return ListView(children: dlist);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var textColor = context.isDarkMode ? Colors.white : Colors.black;
+    return SizedBox(
+      width: double.infinity,
+      height: Get.height * .66,
+      child: Stack(
+        children: [
+          BackdropFilter(
+            filter: ImageFilter.blur(
+              sigmaX: 24,
+              sigmaY: 24,
+            ),
+            child: SizedBox.shrink(),
+          ),
+          Positioned.fill(
+            child: Column(
+              children: [
+                SizedBox(
+                  width: double.infinity,
+                  height: 42,
+                  child: Center(
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      spacing: 12,
+                      children: [
+                        Icon(CupertinoIcons.tv_fill, color: textColor),
+                        Text(
+                          "投屏设备",
+                          style: TextStyle(
+                            fontSize: 18,
+                            color: textColor,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Divider(),
+                Expanded(child: _body()),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/modules/play/views/play_view.dart
+++ b/lib/app/modules/play/views/play_view.dart
@@ -1,14 +1,18 @@
 import 'dart:ui';
 
+import 'package:clipboard/clipboard.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:get/get.dart';
 import 'package:catmovie/app/modules/home/controllers/home_controller.dart';
 import 'package:catmovie/app/modules/home/views/parse_vip_manage.dart';
 import 'package:catmovie/app/widget/helper.dart';
 import 'package:catmovie/app/widget/window_appbar.dart';
 import 'package:catmovie/widget/simple_html/flutter_html.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
+import 'package:pull_down_button/pull_down_button.dart';
 import 'package:simple/x.dart';
 import 'package:xi/xi.dart';
 
@@ -30,10 +34,8 @@ class PlayView extends StatefulWidget {
 class _PlayViewState extends State<PlayView> {
   final PlayController play = Get.find<PlayController>();
   final HomeController home = Get.find<HomeController>();
-
-  FocusNode focusNode = FocusNode();
-
-  ScrollController scrollController = ScrollController();
+  final FocusNode focusNode = FocusNode();
+  final ScrollController scrollController = ScrollController();
 
   bool get canBeShowParseVipButton {
     return home.parseVipList.isNotEmpty;
@@ -373,26 +375,83 @@ class _PlayViewState extends State<PlayView> {
                                     itemBuilder: (context, index) {
                                       var curr =
                                           playlist[play.tabIndex].datas[index];
-                                      return CupertinoButton.filled(
-                                        padding: EdgeInsets.zero,
-                                        child: Builder(builder: (_) {
-                                          var len = playlist[play.tabIndex]
-                                              .datas
-                                              .length;
-                                          var text =
-                                              len <= 1 ? "播放" : curr.name;
-                                          var playState = play.playState;
-                                          if (playState.tabIndex ==
-                                                  play.tabIndex &&
-                                              index == playState.index) {
-                                            text += "(上次播放)";
-                                          }
-                                          return Text(text);
-                                        }),
-                                        onPressed: () {
-                                          handlePlay(play.tabIndex, index);
-                                        },
-                                      );
+                                      String playUrl = curr.url;
+                                      var isCast = playUrl.endsWith(".m3u8") ||
+                                          playUrl.endsWith(".mp4");
+                                      return Builder(builder: (menuContext) {
+                                        return PullDownButton(
+                                          itemBuilder: (context) {
+                                            return [
+                                              PullDownMenuItem(
+                                                onTap: () async {
+                                                  await FlutterClipboard.copy(
+                                                    playUrl,
+                                                  );
+                                                  EasyLoading.showToast(
+                                                    "复制链接成功",
+                                                    maskType:
+                                                        EasyLoadingMaskType
+                                                            .none,
+                                                  );
+                                                },
+                                                title: '复制链接',
+                                                icon: CupertinoIcons
+                                                    .doc_on_clipboard,
+                                              ),
+                                              if (isCast)
+                                                PullDownMenuItem(
+                                                  title: '投屏播放',
+                                                  subtitle: '仅支持局域网里的设备',
+                                                  onTap: () {
+                                                    showCupertinoModalBottomSheet(
+                                                        context: context,
+                                                        builder: (
+                                                          BuildContext context,
+                                                        ) {
+                                                          // TODO: impl this
+                                                          return SizedBox
+                                                              .shrink();
+                                                        });
+                                                  },
+                                                  icon: CupertinoIcons.tv,
+                                                ),
+                                              // PullDownMenuItem(
+                                              //   onTap: () {},
+                                              //   title: '删除',
+                                              //   isDestructive: true,
+                                              //   icon: CupertinoIcons.delete,
+                                              // ),
+                                            ];
+                                          },
+                                          buttonBuilder: (context, showMenu) {
+                                            return CupertinoButton.filled(
+                                              padding: EdgeInsets.zero,
+                                              child: Builder(builder: (cx) {
+                                                var len =
+                                                    playlist[play.tabIndex]
+                                                        .datas
+                                                        .length;
+                                                var text =
+                                                    len <= 1 ? "播放" : curr.name;
+                                                var playState = play.playState;
+                                                if (playState.tabIndex ==
+                                                        play.tabIndex &&
+                                                    index == playState.index) {
+                                                  text += "(上次播放)";
+                                                }
+                                                return Text(text);
+                                              }),
+                                              onPressed: () {
+                                                handlePlay(
+                                                    play.tabIndex, index);
+                                              },
+                                              onLongPress: () {
+                                                showMenu();
+                                              },
+                                            );
+                                          },
+                                        );
+                                      });
                                     },
                                   ),
                                 );

--- a/lib/app/modules/play/views/play_view.dart
+++ b/lib/app/modules/play/views/play_view.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:catmovie/app/modules/play/views/cast_screen.dart';
 import 'package:clipboard/clipboard.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -405,12 +406,54 @@ class _PlayViewState extends State<PlayView> {
                                                   onTap: () {
                                                     showCupertinoModalBottomSheet(
                                                         context: context,
+                                                        backgroundColor:
+                                                            (context.isDarkMode
+                                                                    ? Colors
+                                                                        .black
+                                                                    : Colors
+                                                                        .white)
+                                                                .withValues(
+                                                                    alpha: .88),
                                                         builder: (
                                                           BuildContext context,
                                                         ) {
-                                                          // TODO: impl this
-                                                          return SizedBox
-                                                              .shrink();
+                                                          return CastScreen(
+                                                            onTapDevice:
+                                                                (cx) async {
+                                                              try {
+                                                                await cx.setUrl(
+                                                                    playUrl);
+                                                                await cx.play();
+                                                                // TODO: 支持控制远程DLNA设备
+                                                                if (context
+                                                                    .mounted)
+                                                                  Navigator.of(
+                                                                          context)
+                                                                      .pop();
+                                                                EasyLoading
+                                                                    .showToast(
+                                                                  "即将开始投屏播放",
+                                                                  toastPosition:
+                                                                      EasyLoadingToastPosition
+                                                                          .bottom,
+                                                                  duration: Duration(
+                                                                      milliseconds:
+                                                                          240),
+                                                                );
+                                                              } catch (e) {
+                                                                EasyLoading
+                                                                    .showToast(
+                                                                  "播放失败",
+                                                                  toastPosition:
+                                                                      EasyLoadingToastPosition
+                                                                          .bottom,
+                                                                  duration: Duration(
+                                                                      milliseconds:
+                                                                          240),
+                                                                );
+                                                              }
+                                                            },
+                                                          );
                                                         });
                                                   },
                                                   icon: CupertinoIcons.tv,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -970,6 +970,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  pull_down_button:
+    dependency: "direct main"
+    description:
+      name: pull_down_button
+      sha256: "12cdd8ff187a3150ebdf075e5074299f085579b158d2b4e655ccbafccf95f25b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.2"
   pull_to_refresh_flutter3:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -393,6 +393,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  dlna_dart:
+    dependency: "direct main"
+    description:
+      name: dlna_dart
+      sha256: "8a4f0e4f378615c99f2af679dc9f0c72fe4a0fb2f3eea96b637fe691dfcf0649"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   equatable:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,6 +98,10 @@ dependencies:
   event_bus: ^2.0.1
   window_manager: ^0.5.0
   vclibs: ^0.1.3
+  
+  # 这个插件其实很好, 只不过我在用的发现它的位置算不太准
+  # smart_overlay_menu: ^1.0.0
+  pull_down_button: ^0.10.2
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,6 +103,8 @@ dependencies:
   # smart_overlay_menu: ^1.0.0
   pull_down_button: ^0.10.2
 
+  dlna_dart: ^0.1.0
+
 dev_dependencies:
   flutter_lints: ^6.0.0
 


### PR DESCRIPTION
Closes #87

我想在这个 PR 中实现一个基本的 DLNA 投屏 😁
通过长按选择
![fixxx](https://github.com/user-attachments/assets/6dc58482-2628-46c3-9e16-88e625813a1b)

> ~~暂时入口我想通过长按触发投屏~~
> ![fixxx](https://github.com/user-attachments/assets/966502b5-d179-475b-aed7-905778bf1e80)

本地测试可以使用 [Macast](https://github.com/xfangfang/Macast)

<img width="240" alt="image" src="https://github.com/user-attachments/assets/154c39c7-92ac-483e-987f-a7e01b5bb0d3" />

## TODO

- [x] 添加入口(长按)
  - [x]  引入 [pull_down_button](https://pub.dev/packages/pull_down_button)
  - [ ] ~~引入 [super_context_menu](https://pub.dev/packages/super_context_menu) 的话需要更新~~
    - [ ] ~~文档~~
    - [ ] ~~workflow 中添加 rust 环境~~
  - [ ] ~~备选方案: [flutter-context-menu](https://github.com/gskinnerTeam/flutter-context-menu)~~
- [x] 实现这个功能
  - [x] [dlna_dart](https://pub.dev/packages/dlna_dart)

<img width="393" alt="image" src="https://github.com/user-attachments/assets/3c9c5bb5-8d46-4fe5-8b52-6759dd880536" />

## FIXME

- [ ] 在 macOS 上测试发现扫描不出本地的DLNA设备

macOS/Linux/Windows rewrite?

> https://github.com/waifu-project/go-upnpcast/blob/main/main.go

## NOTE

当系统中占用 1900 端口时, 为了调试请:

```bash
sudo lsof -t -i :1900
# 看一下是那个进程
ps -p $pid
sudo kill -9 $pid
```