### PR TITLE
Experiment: use JS(runtime) rewrite maccms adapter

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -34,6 +34,8 @@ PODS:
     - DKImagePickerController/PhotoGallery
     - Flutter
   - Flutter (1.0.0)
+  - flutter_js (0.1.0):
+    - Flutter
   - isar_flutter_libs (1.0.0):
     - Flutter
   - media_kit_libs_ios_video (1.0.4):
@@ -72,6 +74,7 @@ PODS:
 DEPENDENCIES:
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
+  - flutter_js (from `.symlinks/plugins/flutter_js/ios`)
   - isar_flutter_libs (from `.symlinks/plugins/isar_flutter_libs/ios`)
   - media_kit_libs_ios_video (from `.symlinks/plugins/media_kit_libs_ios_video/ios`)
   - media_kit_video (from `.symlinks/plugins/media_kit_video/ios`)
@@ -98,6 +101,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
     :path: Flutter
+  flutter_js:
+    :path: ".symlinks/plugins/flutter_js/ios"
   isar_flutter_libs:
     :path: ".symlinks/plugins/isar_flutter_libs/ios"
   media_kit_libs_ios_video:
@@ -130,6 +135,7 @@ SPEC CHECKSUMS:
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
   file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_js: 867813c1830e1d9b2c5d547cdb6f61801e2f2145
   isar_flutter_libs: bc909e72c3d756c2759f14c8776c13b5b0556e26
   media_kit_libs_ios_video: 5a18affdb97d1f5d466dc79988b13eff6c5e2854
   media_kit_video: 1746e198cb697d1ffb734b1d05ec429d1fcd1474

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,8 +10,7 @@ import 'package:hide_cursor/hide_cursor.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:protocol_handler/protocol_handler.dart';
 import 'package:window_manager/window_manager.dart';
-import 'package:xi/utils/helper.dart';
-import 'package:xi/utils/http.dart';
+import 'package:xi/xi.dart';
 import 'shared/manage.dart';
 import 'package:catmovie/shared/enum.dart';
 
@@ -41,6 +40,8 @@ Future<ThemeMode> runBefore() async {
   // * https://github.com/media-kit/media-kit#installation
   // * https://pub.dev/packages/media_kit#installation
   MediaKit.ensureInitialized();
+
+  jsRuntime.echo();
 
   // Register a custom protocol
   // For macOS platform needs to declare the scheme in ios/Runner/Info.plist

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <bitsdojo_window_linux/bitsdojo_window_plugin.h>
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
+#include <flutter_js/flutter_js_plugin.h>
 #include <hide_cursor/hide_cursor_plugin.h>
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
@@ -24,6 +25,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) desktop_webview_window_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopWebviewWindowPlugin");
   desktop_webview_window_plugin_register_with_registrar(desktop_webview_window_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_js_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterJsPlugin");
+  flutter_js_plugin_register_with_registrar(flutter_js_registrar);
   g_autoptr(FlPluginRegistrar) hide_cursor_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "HideCursorPlugin");
   hide_cursor_plugin_register_with_registrar(hide_cursor_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   bitsdojo_window_linux
   desktop_webview_window
+  flutter_js
   hide_cursor
   isar_flutter_libs
   media_kit_libs_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import bitsdojo_window_macos
 import desktop_webview_window
 import file_picker
+import flutter_js
 import hide_cursor
 import isar_flutter_libs
 import media_kit_libs_macos_video
@@ -29,6 +30,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   BitsdojoWindowPlugin.register(with: registry.registrar(forPlugin: "BitsdojoWindowPlugin"))
   DesktopWebviewWindowPlugin.register(with: registry.registrar(forPlugin: "DesktopWebviewWindowPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FlutterJsPlugin.register(with: registry.registrar(forPlugin: "FlutterJsPlugin"))
   HideCursorPlugin.register(with: registry.registrar(forPlugin: "HideCursorPlugin"))
   IsarFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "IsarFlutterLibsPlugin"))
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -5,6 +5,8 @@ PODS:
     - FlutterMacOS
   - file_picker (0.0.1):
     - FlutterMacOS
+  - flutter_js (0.0.1):
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - hide_cursor (0.0.1):
     - FlutterMacOS
@@ -47,6 +49,7 @@ DEPENDENCIES:
   - bitsdojo_window_macos (from `Flutter/ephemeral/.symlinks/plugins/bitsdojo_window_macos/macos`)
   - desktop_webview_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_webview_window/macos`)
   - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
+  - flutter_js (from `Flutter/ephemeral/.symlinks/plugins/flutter_js/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - hide_cursor (from `Flutter/ephemeral/.symlinks/plugins/hide_cursor/macos`)
   - isar_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/isar_flutter_libs/macos`)
@@ -72,6 +75,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_webview_window/macos
   file_picker:
     :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
+  flutter_js:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_js/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   hide_cursor:
@@ -111,6 +116,7 @@ SPEC CHECKSUMS:
   bitsdojo_window_macos: 7959fb0ca65a3ccda30095c181ecb856fae48ea9
   desktop_webview_window: 2f0cdefecc06e21208a51589bd3d1580a87a703c
   file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
+  flutter_js: 79c3c70d33ba464c67d8eb88639a61aa718cd8b8
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   hide_cursor: b2c315dcec23c14ece92fbbab9b9c0d33f3a603d
   isar_flutter_libs: a65381780401f81ad6bf3f2e7cd0de5698fb98c4

--- a/packages/xi/lib/adapters/universal.dart
+++ b/packages/xi/lib/adapters/universal.dart
@@ -1,0 +1,51 @@
+import '../interface.dart';
+import 'package:flutter_js/flutter_js.dart';
+
+class UniversalSpider extends ISpiderAdapter {
+  @override
+  Future<VideoDetail> getDetail(String movieId) async {
+    getJavascriptRuntime();
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<VideoDetail>> getHome({
+    int page = 1,
+    int limit = 10,
+    String? category,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<VideoDetail>> getSearch({
+    required String keyword,
+    int page = 1,
+    int limit = 10,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  bool get isNsfw => false;
+
+  @override
+  SourceItemMeta get meta => SourceItemMeta(
+        name: "",
+        logo: "",
+        desc: "",
+        domain: "",
+        id: "",
+        status: false,
+      );
+
+  @override
+  Future<List<SourceSpiderQueryCategory>> getCategory() async {
+    throw UnimplementedError();
+  }
+
+  @override
+  String toString() {
+    return "";
+  }
+}

--- a/packages/xi/lib/utils/js.dart
+++ b/packages/xi/lib/utils/js.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_js/extensions/fetch.dart';
+import 'package:flutter_js/extensions/xhr.dart';
+import 'package:flutter_js/flutter_js.dart';
+
+class JSRuntime {
+  late JavascriptRuntime _cx;
+  JavascriptRuntime get cx => _cx;
+  JSRuntime() {
+    _cx = getJavascriptRuntime();
+    withInit();
+  }
+
+  void withInit() {
+    _cx.enableFetch();
+    _cx.enableHandlePromises();
+    _cx.enableXhr();
+  }
+
+  void echo() async {
+    var x = await _cx.evaluateAsync("""
+function getHome() {
+  return new Promise(async res=> {
+    const resp = await fetch("https://api.52vmy.cn/api/img/tu/girl")
+    const cx = await resp.text()
+    res({ "hello": cx })
+  })
+};
+await getHome()
+""");
+    debugPrint("xx");
+  }
+}
+
+var jsRuntime = JSRuntime();

--- a/packages/xi/lib/utils/utils.dart
+++ b/packages/xi/lib/utils/utils.dart
@@ -5,3 +5,4 @@ export 'path.dart';
 export 'source.dart';
 export 'xid.dart';
 export 'maccms.dart';
+export 'js.dart';

--- a/packages/xi/pubspec.yaml
+++ b/packages/xi/pubspec.yaml
@@ -17,3 +17,7 @@ dependencies:
   path_provider: ^2.1.5
   jsonc: ^0.0.3
   path: ^1.9.1
+  
+  flutter_js:
+     git:
+       url: https://github.com/abner/flutter_js

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -541,6 +541,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
+  flutter_js:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: HEAD
+      resolved-ref: "89f96fd0bef2ff4e8948d7190b34ce7126574972"
+      url: "https://github.com/abner/flutter_js"
+    source: git
+    version: "0.8.5"
   flutter_launcher_name:
     dependency: "direct dev"
     description:
@@ -1377,6 +1386,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.33"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   synchronized:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -125,6 +125,10 @@ dependencies:
   cupertino_onboarding: ^1.3.0
 
   markdown_widget: ^2.3.2+8
+  
+  flutter_js:
+     git:
+       url: https://github.com/abner/flutter_js
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <bitsdojo_window_windows/bitsdojo_window_plugin.h>
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
+#include <flutter_js/flutter_js_plugin.h>
 #include <hide_cursor/hide_cursor_plugin_c_api.h>
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
@@ -25,6 +26,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("BitsdojoWindowPlugin"));
   DesktopWebviewWindowPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DesktopWebviewWindowPlugin"));
+  FlutterJsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterJsPlugin"));
   HideCursorPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("HideCursorPluginCApi"));
   IsarFlutterLibsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   bitsdojo_window_windows
   desktop_webview_window
+  flutter_js
   hide_cursor
   isar_flutter_libs
   media_kit_libs_windows_video


### PR DESCRIPTION
我想在这个PR中用 JS 重新实现 maccms 适配器
在这之后, 我们就 "真的" 可以自己手写源

config:

```jsonc
{
    "type": 0,
    "name": "小猫影视",
    "logo": "",
    "desc": "",
    "nsfw": false,
    "baseUrl": "https://baidu.com"
}
```