### PR TITLE
Patch: add multi video-player kernel

### DIFF
--- a/lib/app/extension.dart
+++ b/lib/app/extension.dart
@@ -19,7 +19,6 @@ extension StringWithColor on String {
   }
 }
 
-/// remove this(mixin object 杀伤力太大)
 extension ISettingMixin on Object {
   IsarCollection<SettingsIsarModel> get settingAs => IsarRepository().settingAs;
   SettingsIsarModel get settingAsValue => IsarRepository().settingsSingleModel;
@@ -39,19 +38,10 @@ extension ISettingMixin on Object {
     return getSettingAsKey(key) as T;
   }
 
-  /// the code is shit|_・)
-  ///
-  /// disgustingε(┬┬﹏┬┬)3
-  ///
-  /// (っ ̯ -｡)
   Object getSettingAsKey(SettingsAllKey key) {
     var curr = settingAsValue;
     if (key == SettingsAllKey.themeMode) {
       return curr.themeMode;
-    } else if (key == SettingsAllKey.iosCanBeUseSystemBrowser) {
-      return curr.iosCanBeUseSystemBrowser;
-    } else if (key == SettingsAllKey.macosPlayUseIINA) {
-      return curr.macosPlayUseIINA;
     } else if (key == SettingsAllKey.isNsfw) {
       return curr.isNSFW;
     } else if (key == SettingsAllKey.mirrorIndex) {
@@ -64,23 +54,16 @@ extension ISettingMixin on Object {
       return curr.webviewPlayType;
     } else if (key == SettingsAllKey.onBoardingShowed) {
       return curr.onBoardingShowed;
+    } else if (key == SettingsAllKey.videoKennel) {
+      return curr.videoKennel;
     }
     return curr.id;
   }
 
-  /// the code is shit|_・)
-  ///
-  /// disgustingε(┬┬﹏┬┬)3
-  ///
-  /// (っ ̯ -｡)
   void updateSetting(SettingsAllKey key, dynamic value) {
     var curr = settingAsValue;
     if (key == SettingsAllKey.themeMode) {
       curr.themeMode = value;
-    } else if (key == SettingsAllKey.iosCanBeUseSystemBrowser) {
-      curr.iosCanBeUseSystemBrowser = value;
-    } else if (key == SettingsAllKey.macosPlayUseIINA) {
-      curr.macosPlayUseIINA = value;
     } else if (key == SettingsAllKey.isNsfw) {
       curr.isNSFW = value;
     } else if (key == SettingsAllKey.mirrorIndex) {
@@ -93,6 +76,8 @@ extension ISettingMixin on Object {
       curr.webviewPlayType = value;
     } else if (key == SettingsAllKey.onBoardingShowed) {
       curr.onBoardingShowed = value;
+    } else if (key == SettingsAllKey.videoKennel) {
+      curr.videoKennel = value;
     } else {
       return;
     }

--- a/lib/app/extension.dart
+++ b/lib/app/extension.dart
@@ -54,8 +54,8 @@ extension ISettingMixin on Object {
       return curr.webviewPlayType;
     } else if (key == SettingsAllKey.onBoardingShowed) {
       return curr.onBoardingShowed;
-    } else if (key == SettingsAllKey.videoKennel) {
-      return curr.videoKennel;
+    } else if (key == SettingsAllKey.videoKernel) {
+      return curr.videoKernel;
     }
     return curr.id;
   }
@@ -76,8 +76,8 @@ extension ISettingMixin on Object {
       curr.webviewPlayType = value;
     } else if (key == SettingsAllKey.onBoardingShowed) {
       curr.onBoardingShowed = value;
-    } else if (key == SettingsAllKey.videoKennel) {
-      curr.videoKennel = value;
+    } else if (key == SettingsAllKey.videoKernel) {
+      curr.videoKernel = value;
     } else {
       return;
     }

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -18,7 +18,6 @@ import 'package:pull_to_refresh_flutter3/pull_to_refresh_flutter3.dart';
 
 import 'package:catmovie/app/extension.dart';
 import 'package:window_manager/window_manager.dart';
-import 'package:xi/adapters/mac_cms.dart';
 import 'package:xi/xi.dart';
 
 const kSmoothListViewDuration = Duration(milliseconds: 210);
@@ -86,8 +85,6 @@ class HomeController extends GetxController
     return currentMirrorItem.meta.id;
   }
 
-  bool _iosCanBeUseSystemBrowser = true;
-
   List<SourceSpiderQueryCategory> get currentCategoryer {
     var data = mirrorCategoryPool.data(currentMirrorItemId);
     if (data.isNotEmpty) {
@@ -108,34 +105,7 @@ class HomeController extends GetxController
     update();
   }
 
-  bool get iosCanBeUseSystemBrowser =>
-      _iosCanBeUseSystemBrowser && GetPlatform.isIOS && !GetPlatform.isLinux;
-
-  set iosCanBeUseSystemBrowser(bool newVal) {
-    _iosCanBeUseSystemBrowser = newVal;
-    update();
-    updateSetting(SettingsAllKey.iosCanBeUseSystemBrowser, newVal);
-  }
-
-  void updateIOSCanBeUseSystemBrowser() {
-    var val =
-        getSettingAsKeyIdent<bool>(SettingsAllKey.iosCanBeUseSystemBrowser);
-    iosCanBeUseSystemBrowser = val;
-  }
-
   bool _isNsfw = false;
-
-  bool _macosPlayUseIINA = false;
-
-  bool get macosPlayUseIINA {
-    return _macosPlayUseIINA;
-  }
-
-  set macosPlayUseIINA(bool newVal) {
-    _macosPlayUseIINA = newVal;
-    update();
-    updateSetting(SettingsAllKey.macosPlayUseIINA, newVal);
-  }
 
   bool get isNsfw {
     return _isNsfw;
@@ -372,8 +342,6 @@ class HomeController extends GetxController
     updateWindowLastSize();
     WidgetsBinding.instance.addObserver(this);
     updateNsfwSetting();
-    updateIOSCanBeUseSystemBrowser();
-    updateMacosPlayUseIINAState();
     updateHomeData(isFirst: true);
     initCacheMirrorTableScrollControllerOffset();
     initMovieParseVipList();
@@ -382,12 +350,6 @@ class HomeController extends GetxController
 
   void updateWindowLastSize() {
     windowLastSize = View.of(Get.context!).physicalSize;
-    update();
-  }
-
-  void updateMacosPlayUseIINAState() {
-    _macosPlayUseIINA =
-        getSettingAsKeyIdent<bool>(SettingsAllKey.macosPlayUseIINA);
     update();
   }
 

--- a/lib/app/modules/home/views/onboarding.dart
+++ b/lib/app/modules/home/views/onboarding.dart
@@ -5,7 +5,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:get/get.dart';
-import 'package:xi/adapters/mac_cms.dart';
 import 'package:xi/models/mac_cms/source_data.dart';
 import 'package:xi/xi.dart';
 

--- a/lib/app/modules/home/views/settings_view.dart
+++ b/lib/app/modules/home/views/settings_view.dart
@@ -408,7 +408,7 @@ class _SettingsViewState extends State<SettingsView>
           ),
           canBeShowIosBrowserSettings
               ? CSControl(
-                  nameWidget: const Text('iOS播放使用内置浏览器'),
+                  nameWidget: const Text('原生浏览器播放'),
                   contentWidget: HoverCursor(
                     child: CupertinoSwitch(
                       value: _canBeShowIosBrowser,
@@ -422,7 +422,7 @@ class _SettingsViewState extends State<SettingsView>
                   ),
                   style: const CSWidgetStyle(
                     icon: Icon(
-                      Icons.airplay_rounded,
+                      CupertinoIcons.play_rectangle_fill,
                     ),
                   ),
                 )
@@ -443,7 +443,7 @@ class _SettingsViewState extends State<SettingsView>
           ),
           if (GetPlatform.isMacOS)
             CSControl(
-              nameWidget: const Text('播放使用IINA(默认内置播放器)'),
+              nameWidget: const Text('IINA播放'),
               contentWidget: HoverCursor(
                 child: CupertinoSwitch(
                   value: macosPlayUseIINA,
@@ -461,7 +461,7 @@ class _SettingsViewState extends State<SettingsView>
               ),
               style: const CSWidgetStyle(
                 icon: Icon(
-                  CupertinoIcons.play_rectangle,
+                  CupertinoIcons.option,
                 ),
               ),
             ),

--- a/lib/app/modules/home/views/settings_view.dart
+++ b/lib/app/modules/home/views/settings_view.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:catmovie/app/modules/home/views/auto_update.dart';
 import 'package:catmovie/app/widget/zoom.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_cupertino_settings/flutter_cupertino_settings.dart';
@@ -21,9 +20,9 @@ import 'package:catmovie/git_info.dart';
 import 'package:catmovie/shared/enum.dart';
 import 'package:catmovie/shared/manage.dart';
 import 'package:catmovie/app/modules/home/views/cupertino_license.dart';
+import 'package:pull_down_button/pull_down_button.dart';
 import 'package:xi/models/mac_cms/source_data.dart';
-import 'package:xi/utils/helper.dart';
-import 'package:xi/utils/source.dart';
+import 'package:xi/xi.dart';
 
 enum GetBackResultType {
   /// 失败
@@ -76,6 +75,8 @@ class _SettingsViewState extends State<SettingsView>
 
   bool _autoDarkMode = false;
 
+  VideoKennel _videoKennel = VideoKennel.webview;
+
   set autoDarkMode(bool newVal) {
     if (newVal) {
       updateSetting(SettingsAllKey.themeMode, SystemThemeMode.system);
@@ -106,9 +107,8 @@ class _SettingsViewState extends State<SettingsView>
           getSettingAsKeyIdent<SystemThemeMode>(SettingsAllKey.themeMode);
       _isDark = themeMode.isDark;
       _autoDarkMode = themeMode.isSytem;
-      _canBeShowIosBrowser =
-          getSettingAsKeyIdent<bool>(SettingsAllKey.iosCanBeUseSystemBrowser);
-      _macosPlayUseIINA = home.macosPlayUseIINA;
+      _videoKennel =
+          getSettingAsKeyIdent<VideoKennel>(SettingsAllKey.videoKennel);
     });
     loadSourceHelp();
     addMirrorMangerTextareaLister();
@@ -244,25 +244,6 @@ class _SettingsViewState extends State<SettingsView>
     }
   }
 
-  /// 是否显示`ios`默认浏览器设置
-  /// linux no support this options!!
-  bool canBeShowIosBrowserSettings =
-      !GetPlatform.isLinux && (GetPlatform.isIOS || kDebugMode);
-
-  bool _canBeShowIosBrowser = true;
-
-  bool _macosPlayUseIINA = false;
-
-  bool get macosPlayUseIINA {
-    return _macosPlayUseIINA;
-  }
-
-  set macosPlayUseIINA(bool newVal) {
-    _macosPlayUseIINA = newVal;
-    setState(() {});
-    home.macosPlayUseIINA = newVal;
-  }
-
   void handleCleanCache() {
     home.clearCache();
     home.confirmAlert(
@@ -271,6 +252,39 @@ class _SettingsViewState extends State<SettingsView>
       confirmText: "我知道了",
       context: context,
     );
+  }
+
+  List<PullDownMenuEntry> _buildVideoKennel() {
+    void action(VideoKennel vk) {
+      _videoKennel = vk;
+      updateSetting(SettingsAllKey.videoKennel, vk);
+      setState(() {});
+    }
+
+    var result = [VideoKennel.webview, VideoKennel.mediaKit].map((item) {
+      return PullDownMenuItem.selectable(
+        selected: item == _videoKennel,
+        onTap: () => action(item),
+        title: item.name,
+      );
+    }).toList();
+    if (GetPlatform.isMacOS) {
+      result.add(
+        PullDownMenuItem.selectable(
+          selected: VideoKennel.iina == _videoKennel,
+          onTap: () {
+            final bool isInstall = checkInstalledIINA();
+            if (!isInstall) {
+              EasyLoading.showError("未安装IINA, 请先安装!");
+              return;
+            }
+            action(VideoKennel.iina);
+          },
+          title: VideoKennel.iina.name,
+        ),
+      );
+    }
+    return result;
   }
 
   @override
@@ -406,27 +420,28 @@ class _SettingsViewState extends State<SettingsView>
               );
             },
           ),
-          canBeShowIosBrowserSettings
-              ? CSControl(
-                  nameWidget: const Text('原生浏览器播放'),
-                  contentWidget: HoverCursor(
-                    child: CupertinoSwitch(
-                      value: _canBeShowIosBrowser,
-                      onChanged: (bool value) async {
-                        setState(() {
-                          _canBeShowIosBrowser = value;
-                        });
-                        home.iosCanBeUseSystemBrowser = value;
-                      },
-                    ),
-                  ),
-                  style: const CSWidgetStyle(
-                    icon: Icon(
-                      CupertinoIcons.play_rectangle_fill,
-                    ),
-                  ),
-                )
-              : const SizedBox.shrink(),
+          CSControl(
+            nameWidget: const Text("播放器内核"),
+            contentWidget: HoverCursor(
+              child: PullDownButton(
+                itemBuilder: (cx) {
+                  return _buildVideoKennel();
+                },
+                buttonBuilder: (cx, showMenu) {
+                  return CupertinoButton(
+                    padding: EdgeInsets.zero,
+                    onPressed: showMenu,
+                    child: Text(_videoKennel.name),
+                  );
+                },
+              ),
+            ),
+            style: const CSWidgetStyle(
+              icon: Icon(
+                CupertinoIcons.macwindow,
+              ),
+            ),
+          ),
           CSControl(
             nameWidget: const Text('成人模式'),
             contentWidget: HoverCursor(
@@ -441,30 +456,6 @@ class _SettingsViewState extends State<SettingsView>
               icon: Icon(CupertinoIcons.hammer_fill),
             ),
           ),
-          if (GetPlatform.isMacOS)
-            CSControl(
-              nameWidget: const Text('IINA播放'),
-              contentWidget: HoverCursor(
-                child: CupertinoSwitch(
-                  value: macosPlayUseIINA,
-                  onChanged: (bool value) async {
-                    if (value) {
-                      final bool isInstall = checkInstalledIINA();
-                      if (!isInstall) {
-                        EasyLoading.showError("未安装IINA, 请先安装!");
-                        return;
-                      }
-                    }
-                    macosPlayUseIINA = value;
-                  },
-                ),
-              ),
-              style: const CSWidgetStyle(
-                icon: Icon(
-                  CupertinoIcons.option,
-                ),
-              ),
-            ),
           const CSHeader('其他设置'),
           GestureDetector(
             onTap: () {

--- a/lib/app/modules/home/views/settings_view.dart
+++ b/lib/app/modules/home/views/settings_view.dart
@@ -75,7 +75,7 @@ class _SettingsViewState extends State<SettingsView>
 
   bool _autoDarkMode = false;
 
-  VideoKennel _videoKennel = VideoKennel.webview;
+  VideoKernel _videoKernel = VideoKernel.webview;
 
   set autoDarkMode(bool newVal) {
     if (newVal) {
@@ -107,8 +107,8 @@ class _SettingsViewState extends State<SettingsView>
           getSettingAsKeyIdent<SystemThemeMode>(SettingsAllKey.themeMode);
       _isDark = themeMode.isDark;
       _autoDarkMode = themeMode.isSytem;
-      _videoKennel =
-          getSettingAsKeyIdent<VideoKennel>(SettingsAllKey.videoKennel);
+      _videoKernel =
+          getSettingAsKeyIdent<VideoKernel>(SettingsAllKey.videoKernel);
     });
     loadSourceHelp();
     addMirrorMangerTextareaLister();
@@ -254,16 +254,16 @@ class _SettingsViewState extends State<SettingsView>
     );
   }
 
-  List<PullDownMenuEntry> _buildVideoKennel() {
-    void action(VideoKennel vk) {
-      _videoKennel = vk;
-      updateSetting(SettingsAllKey.videoKennel, vk);
+  List<PullDownMenuEntry> _buildVideoKernel() {
+    void action(VideoKernel vk) {
+      _videoKernel = vk;
+      updateSetting(SettingsAllKey.videoKernel, vk);
       setState(() {});
     }
 
-    var result = [VideoKennel.webview, VideoKennel.mediaKit].map((item) {
+    var result = [VideoKernel.webview, VideoKernel.mediaKit].map((item) {
       return PullDownMenuItem.selectable(
-        selected: item == _videoKennel,
+        selected: item == _videoKernel,
         onTap: () => action(item),
         title: item.name,
       );
@@ -271,16 +271,16 @@ class _SettingsViewState extends State<SettingsView>
     if (GetPlatform.isMacOS) {
       result.add(
         PullDownMenuItem.selectable(
-          selected: VideoKennel.iina == _videoKennel,
+          selected: VideoKernel.iina == _videoKernel,
           onTap: () {
             final bool isInstall = checkInstalledIINA();
             if (!isInstall) {
               EasyLoading.showError("未安装IINA, 请先安装!");
               return;
             }
-            action(VideoKennel.iina);
+            action(VideoKernel.iina);
           },
-          title: VideoKennel.iina.name,
+          title: VideoKernel.iina.name,
         ),
       );
     }
@@ -425,13 +425,13 @@ class _SettingsViewState extends State<SettingsView>
             contentWidget: HoverCursor(
               child: PullDownButton(
                 itemBuilder: (cx) {
-                  return _buildVideoKennel();
+                  return _buildVideoKernel();
                 },
                 buttonBuilder: (cx, showMenu) {
                   return CupertinoButton(
                     padding: EdgeInsets.zero,
                     onPressed: showMenu,
-                    child: Text(_videoKennel.name),
+                    child: Text(_videoKernel.name),
                   );
                 },
               ),

--- a/lib/app/modules/home/views/source_help.dart
+++ b/lib/app/modules/home/views/source_help.dart
@@ -12,7 +12,6 @@ import 'package:catmovie/app/widget/k_error_stack.dart';
 import 'package:catmovie/app/widget/window_appbar.dart';
 import 'package:catmovie/shared/manage.dart';
 import 'package:smooth_list_view/smooth_list_view.dart';
-import 'package:xi/adapters/mac_cms.dart';
 import 'package:catmovie/shared/enum.dart';
 import 'package:xi/xi.dart';
 

--- a/lib/app/modules/play/controllers/play_controller.dart
+++ b/lib/app/modules/play/controllers/play_controller.dart
@@ -337,7 +337,7 @@ document.addEventListener('DOMContentLoaded', function() {
     VideoInfo curr,
     List<VideoInfo> playList,
     int tabIndex,
-    VideoKennel videoKennel,
+    VideoKernel videoKernel,
     Player mediaKitPlayer,
   ) async {
     var url = curr.url;
@@ -382,8 +382,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     debugPrint("current play url is: $url");
 
-    switch (videoKennel) {
-      case VideoKennel.webview:
+    switch (videoKernel) {
+      case VideoKernel.webview:
         if (GetPlatform.isDesktop) {
           return await playWithWebview(playList, curr, url);
         } else {
@@ -407,7 +407,7 @@ document.addEventListener('DOMContentLoaded', function() {
           }
         }
         break;
-      case VideoKennel.iina:
+      case VideoKernel.iina:
         if (!GetPlatform.isMacOS) {
           EasyLoading.showError("该平台不支持 iina 播放");
           return false;
@@ -419,7 +419,7 @@ document.addEventListener('DOMContentLoaded', function() {
           url.openToIINA();
         }
         break;
-      case VideoKennel.mediaKit:
+      case VideoKernel.mediaKit:
         if (curr.type == VideoType.iframe) {
           EasyLoading.showError("Media-Kit不支持iframe播放");
           return false;

--- a/lib/app/modules/play/controllers/play_controller.dart
+++ b/lib/app/modules/play/controllers/play_controller.dart
@@ -1,20 +1,20 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:catmovie/app/modules/play/views/chewie_view.dart';
 import 'package:catmovie/app/modules/play/views/play_view.dart';
 import 'package:desktop_webview_window/desktop_webview_window.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:get/get.dart';
 import 'package:catmovie/app/extension.dart';
 import 'package:catmovie/app/modules/home/controllers/home_controller.dart';
 import 'package:catmovie/app/modules/home/views/source_help.dart';
-import 'package:catmovie/app/modules/play/views/chewie_view.dart';
 import 'package:catmovie/app/modules/play/views/webview_view.dart';
 import 'package:catmovie/shared/auto_injector.dart';
-import 'package:xi/adapters/mac_cms.dart';
-import 'package:xi/interface.dart';
+import 'package:media_kit/media_kit.dart';
 import 'package:xi/xi.dart';
 import 'package:catmovie/isar/schema/parse_schema.dart';
 import 'package:catmovie/shared/enum.dart';
@@ -209,10 +209,136 @@ document.addEventListener('DOMContentLoaded', function() {
     update();
   }
 
+  Future<bool> playWithWebview(
+    List<VideoInfo> playList,
+    VideoInfo curr,
+    String url,
+  ) async {
+    if (GetPlatform.isWindows) {
+      bool bWebviewWindow = await WebviewWindow.isWebviewAvailable();
+      if (!bWebviewWindow) {
+        showCupertinoDialog(
+          builder: (BuildContext context) => CupertinoAlertDialog(
+            title: const Text('提示'),
+            content: const Padding(
+              padding: EdgeInsets.symmetric(
+                vertical: 12.0,
+              ),
+              child: Text(
+                '未安装 edge webview runtime, 无法播放 :(',
+                style: TextStyle(
+                  fontSize: 18,
+                ),
+              ),
+            ),
+            actions: <CupertinoDialogAction>[
+              CupertinoDialogAction(
+                child: const Text(
+                  '我知道了',
+                  style: TextStyle(
+                    color: Color.fromARGB(255, 51, 22, 20),
+                  ),
+                ),
+                onPressed: () {
+                  Get.back();
+                },
+              ),
+              CupertinoDialogAction(
+                isDestructiveAction: true,
+                onPressed: () {
+                  _kWindowsWebviewRuntimeLink.openURL();
+                  Get.back();
+                },
+                child: const Text(
+                  '去下载',
+                  style: TextStyle(
+                    color: Colors.blue,
+                  ),
+                ),
+              )
+            ],
+          ),
+          context: Get.context as BuildContext,
+        );
+      }
+      return false;
+    }
+
+    Webview webview = await WebviewWindow.create(
+      configuration: CreateConfiguration(
+        titleBarHeight: GetPlatform.isMacOS ? 24 : 0,
+        title: "小猫影视",
+      ),
+    );
+
+    void setWebviewActivePlay(VideoInfo curr) {
+      webview.evaluateJavaScript("setActionText(`${curr.name}`)");
+      webview.evaluateJavaScript("setActiveWithPlaylist(`${curr.url}`)");
+    }
+
+    void updatePlayStateWithUrl(String url) {
+      int index = playList.indexWhere(
+        (item) => item.url == url,
+      );
+      if (index >= 0) {
+        updatePlayState(tabIndex, index);
+      }
+    }
+
+    /// `MP4` 理论上来说不需要操作就可以直接喂给浏览器?
+    if (!(await webPlayerEmbedded.checkRunning())) {
+      await webPlayerEmbedded.createServer(
+        port: kWebPlayerEmbeddedPort,
+        onMessage: (msg) {
+          String value = jsonDecode(msg.value);
+          switch (msg.type) {
+            case "switchVideo":
+              updatePlayStateWithUrl(value);
+          }
+        },
+      );
+    }
+
+    url = url2Iframe(url);
+    debugPrint("webview url: $url");
+    // NOTE(d1y): linux 不支持?
+    webview.launch(url);
+
+    // (不需要解析)白嫖的第三方资源会自动跳转广告网站, 这个方法将延迟删除广告
+    // NOTE(d1y): 果真需要吗?
+    // if (!needParse) {
+    //   int beforeRemoveADTime = 1200;
+    //   String execCode =
+    //       "alert('$webviewShowMessage');setTimeout(function() {window.removeEventListener('click', _popwnd_open);}, $beforeRemoveADTime)";
+    //   webview.addScriptToExecuteOnDocumentCreated(execCode);
+    // }
+
+    webview.setOnUrlRequestCallback((newUrl) {
+      updatePlayStateWithUrl(newUrl);
+      Future.delayed(kDelayExecInjectPlaylistJSCode, () async {
+        var curr = playList.firstWhere((element) => element.url == newUrl);
+        setWebviewActivePlay(curr);
+      });
+      return true;
+    });
+
+    if (playList.length >= 2) {
+      webview.addScriptToExecuteOnDocumentCreated(
+        await injectPlaylistJSCode(playList, GetPlatform.isMacOS ? 0 : 12),
+      );
+      Future.delayed(kDelayExecInjectPlaylistJSCode, () async {
+        setWebviewActivePlay(curr);
+      });
+    }
+    return true;
+  }
+
   Future<bool> handleTapPlayerButtom(
     VideoInfo curr,
     List<VideoInfo> playList,
     int tabIndex,
+    VideoKennel videoKennel,
+    Player mediaKitPlayer,
   ) async {
     var url = curr.url;
     url = getPlayUrl(url);
@@ -254,160 +380,54 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     }
 
-    debugPrint("play url: [$url]");
+    debugPrint("current play url is: $url");
 
-    bool isWindows = GetPlatform.isWindows;
-    bool isMacos = GetPlatform.isMacOS;
-
-    /// https://github.com/MixinNetwork/flutter-plugins/tree/main/packages/desktop_webview_window
-    /// 该插件支持 `windows` | `linux`(<然而[webview.launch]方法不支持:(>) | `macos`
-    if (isWindows || isMacos) {
-      if (isMacos && home.macosPlayUseIINA) {
-        url.openToIINA(); // 家人们, 我们就假装安装了
-        return true;
-      }
-
-      if (isWindows) {
-        bool bWebviewWindow = await WebviewWindow.isWebviewAvailable();
-        if (!bWebviewWindow) {
-          showCupertinoDialog(
-            builder: (BuildContext context) => CupertinoAlertDialog(
-              title: const Text('提示'),
-              content: const Padding(
-                padding: EdgeInsets.symmetric(
-                  vertical: 12.0,
-                ),
-                child: Text(
-                  '未安装 edge webview runtime, 无法播放 :(',
-                  style: TextStyle(
-                    fontSize: 18,
-                  ),
-                ),
-              ),
-              actions: <CupertinoDialogAction>[
-                CupertinoDialogAction(
-                  child: const Text(
-                    '我知道了',
-                    style: TextStyle(
-                      color: Colors.red,
-                    ),
-                  ),
-                  onPressed: () {
-                    Get.back();
-                  },
-                ),
-                CupertinoDialogAction(
-                  isDestructiveAction: true,
-                  onPressed: () {
-                    _kWindowsWebviewRuntimeLink.openToIINA();
-                    Get.back();
-                  },
-                  child: const Text(
-                    '去下载',
-                    style: TextStyle(
-                      color: Colors.blue,
-                    ),
-                  ),
-                )
-              ],
-            ),
-            context: Get.context as BuildContext,
-          );
+    switch (videoKennel) {
+      case VideoKennel.webview:
+        if (GetPlatform.isDesktop) {
+          return await playWithWebview(playList, curr, url);
+        } else {
+          if (GetPlatform.isAndroid) {
+            if (curr.type == VideoType.iframe) {
+              Get.to(
+                () => const WebviewView(),
+                arguments: url,
+              );
+            } else {
+              Get.to(
+                () => const ChewieView(),
+                arguments: {
+                  'url': url,
+                  'cover': movieItem.smallCoverImage,
+                },
+              );
+            }
+          } else {
+            url.openURL();
+          }
+        }
+        break;
+      case VideoKennel.iina:
+        if (!GetPlatform.isMacOS) {
+          EasyLoading.showError("该平台不支持 iina 播放");
           return false;
         }
-      }
-
-      Webview webview = await WebviewWindow.create(
-        configuration: CreateConfiguration(
-          titleBarHeight: GetPlatform.isMacOS ? 24 : 0,
-          title: "小猫影视",
-        ),
-      );
-
-      void setWebviewActivePlay(VideoInfo curr) {
-        webview.evaluateJavaScript("setActionText(`${curr.name}`)");
-        webview.evaluateJavaScript("setActiveWithPlaylist(`${curr.url}`)");
-      }
-
-      void updatePlayStateWithUrl(String url) {
-        int index = playList.indexWhere(
-          (item) => item.url == url,
-        );
-        if (index >= 0) {
-          updatePlayState(tabIndex, index);
+        if (curr.type == VideoType.iframe) {
+          EasyLoading.showError("IINA不支持iframe播放");
+          return false;
+        } else {
+          url.openToIINA();
         }
-      }
-
-      /// `MP4` 理论上来说不需要操作就可以直接喂给浏览器?
-      if (!(await webPlayerEmbedded.checkRunning())) {
-        await webPlayerEmbedded.createServer(
-          port: kWebPlayerEmbeddedPort,
-          onMessage: (msg) {
-            String value = jsonDecode(msg.value);
-            switch (msg.type) {
-              case "switchVideo":
-                updatePlayStateWithUrl(value);
-            }
-          },
-        );
-      }
-      url = url2Iframe(url);
-      debugPrint("webview url: $url");
-      webview.launch(url);
-
-      // (不需要解析)白嫖的第三方资源会自动跳转广告网站, 这个方法将延迟删除广告
-      // NOTE(d1y): 果真需要吗?
-      // if (!needParse) {
-      //   int beforeRemoveADTime = 1200;
-      //   String execCode =
-      //       "alert('$webviewShowMessage');setTimeout(function() {window.removeEventListener('click', _popwnd_open);}, $beforeRemoveADTime)";
-      //   webview.addScriptToExecuteOnDocumentCreated(execCode);
-      // }
-
-      webview.setOnUrlRequestCallback((newUrl) {
-        updatePlayStateWithUrl(newUrl);
-        Future.delayed(kDelayExecInjectPlaylistJSCode, () async {
-          var curr = playList.firstWhere((element) => element.url == newUrl);
-          setWebviewActivePlay(curr);
-        });
-        return true;
-      });
-
-      if (playList.length >= 2) {
-        webview.addScriptToExecuteOnDocumentCreated(
-          await injectPlaylistJSCode(playList, GetPlatform.isMacOS ? 0 : 12),
-        );
-        Future.delayed(kDelayExecInjectPlaylistJSCode, () async {
-          setWebviewActivePlay(curr);
-        });
-      }
-
-      return true;
+        break;
+      case VideoKennel.mediaKit:
+        if (curr.type == VideoType.iframe) {
+          EasyLoading.showError("Media-Kit不支持iframe播放");
+          return false;
+        }
+        mediaKitPlayer.open(Media(url));
+        break;
     }
 
-    /// (`m3u8` | `mp4`) 资源
-    var canUseChewieView = [VideoType.m3u8, VideoType.mp4].contains(curr.type);
-
-    /// iOS
-    if (home.iosCanBeUseSystemBrowser) {
-      url.openURL();
-      return true;
-    }
-
-    if (curr.type == VideoType.iframe) {
-      Get.to(
-        () => const WebviewView(),
-        arguments: url,
-      );
-    } else if (canUseChewieView) {
-      Get.to(
-        () => const ChewieView(),
-        arguments: {
-          'url': url,
-          'cover': movieItem.smallCoverImage,
-        },
-      );
-    }
     return true;
   }
 

--- a/lib/app/modules/play/views/play_view.dart
+++ b/lib/app/modules/play/views/play_view.dart
@@ -13,11 +13,13 @@ import 'package:catmovie/app/modules/home/views/parse_vip_manage.dart';
 import 'package:catmovie/app/widget/helper.dart';
 import 'package:catmovie/app/widget/window_appbar.dart';
 import 'package:catmovie/widget/simple_html/flutter_html.dart';
+import 'package:media_kit_video/media_kit_video.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:pull_down_button/pull_down_button.dart';
 import 'package:simple/x.dart';
 import 'package:smooth_list_view/smooth_list_view.dart';
 import 'package:xi/xi.dart';
+import 'package:media_kit/media_kit.dart';
 
 import '../controllers/play_controller.dart';
 
@@ -39,6 +41,9 @@ class _PlayViewState extends State<PlayView> {
   final HomeController home = Get.find<HomeController>();
   final FocusNode focusNode = FocusNode();
   final ScrollController scrollController = ScrollController();
+
+  late final Player player = Player();
+  late final controller = VideoController(player);
 
   bool get canBeShowParseVipButton {
     return home.parseVipList.isNotEmpty;
@@ -72,6 +77,14 @@ class _PlayViewState extends State<PlayView> {
   void initState() {
     focusNode.requestFocus();
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    player.dispose().catchError((error) {
+      debugPrint("player dispose error: $error");
+    });
+    super.dispose();
   }
 
   Future<void> handlePlay(int tabIndex, int index) async {
@@ -186,66 +199,74 @@ class _PlayViewState extends State<PlayView> {
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Container(
+                        SizedBox(
                           width: double.infinity,
-                          height: screenHeight * coverHeightScale,
-                          decoration: const BoxDecoration(
-                            color: Color.fromRGBO(246, 246, 246, 1),
-                          ),
-                          child: Stack(
-                            children: [
-                              Positioned.fill(
-                                child: Image.network(
-                                  play.movieItem.smallCoverImage,
-                                  fit: BoxFit.contain,
-                                  errorBuilder: (_, __, ___) {
-                                    return Image.asset(
-                                      K_DEFAULT_IMAGE,
-                                      fit: BoxFit.cover,
-                                    );
-                                  },
-                                ),
-                              ),
-                              Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  const Expanded(child: SizedBox.shrink()),
-                                  Container(
-                                    width: double.infinity,
-                                    clipBehavior: Clip.antiAlias,
-                                    decoration: const BoxDecoration(
-                                      color: Colors.black12,
-                                    ),
-                                    child: BackdropFilter(
-                                      filter: ImageFilter.blur(
-                                        sigmaX: 24,
-                                        sigmaY: 24,
-                                      ),
-                                      child: Padding(
-                                        padding: const EdgeInsets.symmetric(
-                                          vertical: 12,
-                                          horizontal: 24,
-                                        ),
-                                        child: Text(
-                                          play.movieItem.title,
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .titleLarge
-                                              ?.copyWith(
-                                                  color: context.isDarkMode
-                                                      ? Colors.white
-                                                      : Colors.black),
-                                          overflow: TextOverflow.ellipsis,
-                                          maxLines: 4,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ],
+                          height: 420,
+                          child: Video(
+                            controller: controller,
                           ),
                         ),
+                        if (false)
+                          Container(
+                            width: double.infinity,
+                            height: screenHeight * coverHeightScale,
+                            decoration: const BoxDecoration(
+                              color: Color.fromRGBO(246, 246, 246, 1),
+                            ),
+                            child: Stack(
+                              children: [
+                                Positioned.fill(
+                                  child: Image.network(
+                                    play.movieItem.smallCoverImage,
+                                    fit: BoxFit.contain,
+                                    errorBuilder: (_, __, ___) {
+                                      return Image.asset(
+                                        K_DEFAULT_IMAGE,
+                                        fit: BoxFit.cover,
+                                      );
+                                    },
+                                  ),
+                                ),
+                                Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    const Expanded(child: SizedBox.shrink()),
+                                    Container(
+                                      width: double.infinity,
+                                      clipBehavior: Clip.antiAlias,
+                                      decoration: const BoxDecoration(
+                                        color: Colors.black12,
+                                      ),
+                                      child: BackdropFilter(
+                                        filter: ImageFilter.blur(
+                                          sigmaX: 24,
+                                          sigmaY: 24,
+                                        ),
+                                        child: Padding(
+                                          padding: const EdgeInsets.symmetric(
+                                            vertical: 12,
+                                            horizontal: 24,
+                                          ),
+                                          child: Text(
+                                            play.movieItem.title,
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .titleLarge
+                                                ?.copyWith(
+                                                    color: context.isDarkMode
+                                                        ? Colors.white
+                                                        : Colors.black),
+                                            overflow: TextOverflow.ellipsis,
+                                            maxLines: 4,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
                         Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
@@ -496,8 +517,14 @@ class _PlayViewState extends State<PlayView> {
                                                   return Text(text);
                                                 }),
                                                 onPressed: () {
-                                                  handlePlay(
-                                                      play.tabIndex, index);
+                                                  var curr =
+                                                      playlist[play.tabIndex]
+                                                          .datas[index];
+                                                  debugPrint(
+                                                      "uri is ${curr.url}");
+                                                  player.open(Media(curr.url));
+                                                  // handlePlay(
+                                                  //     play.tabIndex, index);
                                                 },
                                                 onLongPress: () {
                                                   showMenu();

--- a/lib/app/modules/play/views/play_view.dart
+++ b/lib/app/modules/play/views/play_view.dart
@@ -1,7 +1,10 @@
 import 'dart:ui';
 
+import 'package:catmovie/app/extension.dart';
+import 'package:catmovie/app/modules/play/controllers/play_controller.dart';
 import 'package:catmovie/app/modules/play/views/cast_screen.dart';
 import 'package:catmovie/app/widget/zoom.dart';
+import 'package:catmovie/shared/enum.dart';
 import 'package:clipboard/clipboard.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -20,8 +23,6 @@ import 'package:simple/x.dart';
 import 'package:smooth_list_view/smooth_list_view.dart';
 import 'package:xi/xi.dart';
 import 'package:media_kit/media_kit.dart';
-
-import '../controllers/play_controller.dart';
 
 class PlayState {
   const PlayState(this.tabIndex, this.index);
@@ -44,6 +45,8 @@ class _PlayViewState extends State<PlayView> {
 
   late final Player player = Player();
   late final controller = VideoController(player);
+
+  VideoKennel videoKennel = VideoKennel.webview;
 
   bool get canBeShowParseVipButton {
     return home.parseVipList.isNotEmpty;
@@ -76,6 +79,8 @@ class _PlayViewState extends State<PlayView> {
   @override
   void initState() {
     focusNode.requestFocus();
+    videoKennel = getSettingAsKeyIdent<VideoKennel>(SettingsAllKey.videoKennel);
+    if (mounted) setState(() {});
     super.initState();
   }
 
@@ -90,8 +95,15 @@ class _PlayViewState extends State<PlayView> {
   Future<void> handlePlay(int tabIndex, int index) async {
     var realPlaylist = playlist[tabIndex].datas;
     var curr = playlist[tabIndex].datas[index];
-    if (!await play.handleTapPlayerButtom(curr, realPlaylist, tabIndex)) return;
-    Future.delayed(const Duration(milliseconds: 420), () {
+    var isOk = await play.handleTapPlayerButtom(
+      curr,
+      realPlaylist,
+      tabIndex,
+      videoKennel,
+      player,
+    );
+    if (!isOk) return;
+    Future.delayed(const Duration(milliseconds: 240), () {
       play.updatePlayState(tabIndex, index);
     });
   }
@@ -199,14 +211,15 @@ class _PlayViewState extends State<PlayView> {
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        SizedBox(
-                          width: double.infinity,
-                          height: 420,
-                          child: Video(
-                            controller: controller,
-                          ),
-                        ),
-                        if (false)
+                        if (videoKennel.isMediaKit)
+                          SizedBox(
+                            width: double.infinity,
+                            height: 420,
+                            child: Video(
+                              controller: controller,
+                            ),
+                          )
+                        else
                           Container(
                             width: double.infinity,
                             height: screenHeight * coverHeightScale,
@@ -517,14 +530,10 @@ class _PlayViewState extends State<PlayView> {
                                                   return Text(text);
                                                 }),
                                                 onPressed: () {
-                                                  var curr =
-                                                      playlist[play.tabIndex]
-                                                          .datas[index];
-                                                  debugPrint(
-                                                      "uri is ${curr.url}");
-                                                  player.open(Media(curr.url));
-                                                  // handlePlay(
-                                                  //     play.tabIndex, index);
+                                                  handlePlay(
+                                                    play.tabIndex,
+                                                    index,
+                                                  );
                                                 },
                                                 onLongPress: () {
                                                   showMenu();

--- a/lib/app/modules/play/views/play_view.dart
+++ b/lib/app/modules/play/views/play_view.dart
@@ -46,7 +46,7 @@ class _PlayViewState extends State<PlayView> {
   late final Player player = Player();
   late final controller = VideoController(player);
 
-  VideoKennel videoKennel = VideoKennel.webview;
+  VideoKernel videoKernel= VideoKernel.webview;
 
   bool get canBeShowParseVipButton {
     return home.parseVipList.isNotEmpty;
@@ -79,7 +79,7 @@ class _PlayViewState extends State<PlayView> {
   @override
   void initState() {
     focusNode.requestFocus();
-    videoKennel = getSettingAsKeyIdent<VideoKennel>(SettingsAllKey.videoKennel);
+    videoKernel = getSettingAsKeyIdent<VideoKernel>(SettingsAllKey.videoKernel);
     if (mounted) setState(() {});
     super.initState();
   }
@@ -99,7 +99,7 @@ class _PlayViewState extends State<PlayView> {
       curr,
       realPlaylist,
       tabIndex,
-      videoKennel,
+      videoKernel,
       player,
     );
     if (!isOk) return;
@@ -211,7 +211,7 @@ class _PlayViewState extends State<PlayView> {
                       mainAxisAlignment: MainAxisAlignment.start,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        if (videoKennel.isMediaKit)
+                        if (videoKernel.isMediaKit)
                           SizedBox(
                             width: double.infinity,
                             height: 420,

--- a/lib/app/shared/mirror_status_stack.dart
+++ b/lib/app/shared/mirror_status_stack.dart
@@ -1,5 +1,4 @@
 import 'package:catmovie/shared/manage.dart';
-import 'package:xi/adapters/mac_cms.dart';
 import 'package:xi/xi.dart';
 import 'package:xi/models/mac_cms/source_data.dart';
 

--- a/lib/builtin/maccms/maccms.dart
+++ b/lib/builtin/maccms/maccms.dart
@@ -1,3 +1,3 @@
-import 'package:xi/adapters/mac_cms.dart';
+import 'package:xi/xi.dart';
 
 List<MacCMSSpider> list$ = [];

--- a/lib/isar/schema/settings_schema.dart
+++ b/lib/isar/schema/settings_schema.dart
@@ -12,15 +12,11 @@ class SettingsIsarModel {
   @Enumerated(EnumType.ordinal)
   SystemThemeMode themeMode = SystemThemeMode.system;
 
-  /// `ios` 播放视频是否使用默认的系统浏览器
-  /// 1. 浏览器默认支持: `m3u8` | `mp4`
-  /// 2. 网页可以直接跳转给浏览器用
-  /// (所以`ios`默认直接走浏览器岂不美哉?)
-  bool iosCanBeUseSystemBrowser = true;
+  /// 播放器内核
+  @Enumerated(EnumType.ordinal)
+  VideoKennel videoKennel = VideoKennel.webview;
 
-  /// macos播放使用 [iina](https://iina.io)
-  bool macosPlayUseIINA = false;
-
+  /// 是否开启成人模式
   bool isNSFW = false;
 
   /// 当前源

--- a/lib/isar/schema/settings_schema.dart
+++ b/lib/isar/schema/settings_schema.dart
@@ -14,7 +14,7 @@ class SettingsIsarModel {
 
   /// 播放器内核
   @Enumerated(EnumType.ordinal)
-  VideoKennel videoKennel = VideoKennel.webview;
+  VideoKernel videoKernel = VideoKernel.webview;
 
   /// 是否开启成人模式
   bool isNSFW = false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,8 +10,7 @@ import 'package:hide_cursor/hide_cursor.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:protocol_handler/protocol_handler.dart';
 import 'package:window_manager/window_manager.dart';
-import 'package:xi/utils/helper.dart';
-import 'package:xi/utils/http.dart';
+import 'package:xi/xi.dart';
 import 'shared/manage.dart';
 import 'package:catmovie/shared/enum.dart';
 

--- a/lib/shared/enum.dart
+++ b/lib/shared/enum.dart
@@ -10,25 +10,25 @@ enum SystemThemeMode {
   dark,
 }
 
-enum VideoKennel {
+enum VideoKernel {
   webview,
   mediaKit,
   /// macos 专属
   iina,
 }
 
-extension  VideoKennelExtension on VideoKennel {
-  bool get isWebview => this == VideoKennel.webview;
-  bool get isMediaKit => this == VideoKennel.mediaKit;
-  bool get isIina => this == VideoKennel.iina;
+extension  VideoKernelExtension on VideoKernel {
+  bool get isWebview => this == VideoKernel.webview;
+  bool get isMediaKit => this == VideoKernel.mediaKit;
+  bool get isIina => this == VideoKernel.iina;
 
   String get name {
     switch (this) {
-      case VideoKennel.webview:
+      case VideoKernel.webview:
         return "Webview";
-      case VideoKennel.mediaKit:
+      case VideoKernel.mediaKit:
         return "MediaKit";
-      case VideoKennel.iina:
+      case VideoKernel.iina:
         return "IINA";
     }
   }
@@ -55,7 +55,7 @@ enum SettingsAllKey {
   /// 主题
   themeMode,
   /// 播放器内核
-  videoKennel,
+  videoKernel,
   /// 是否开启成人模式
   isNsfw,
   /// 当前源(索引)

--- a/lib/shared/enum.dart
+++ b/lib/shared/enum.dart
@@ -10,6 +10,30 @@ enum SystemThemeMode {
   dark,
 }
 
+enum VideoKennel {
+  webview,
+  mediaKit,
+  /// macos 专属
+  iina,
+}
+
+extension  VideoKennelExtension on VideoKennel {
+  bool get isWebview => this == VideoKennel.webview;
+  bool get isMediaKit => this == VideoKennel.mediaKit;
+  bool get isIina => this == VideoKennel.iina;
+
+  String get name {
+    switch (this) {
+      case VideoKennel.webview:
+        return "Webview";
+      case VideoKennel.mediaKit:
+        return "MediaKit";
+      case VideoKennel.iina:
+        return "IINA";
+    }
+  }
+}
+
 extension SystemThemeModeExtension on SystemThemeMode {
   bool get isSytem => this == SystemThemeMode.system;
   bool get isLight => this == SystemThemeMode.light;
@@ -28,14 +52,21 @@ extension SystemThemeModeExtension on SystemThemeMode {
 }
 
 enum SettingsAllKey {
+  /// 主题
   themeMode,
-  iosCanBeUseSystemBrowser,
-  macosPlayUseIINA,
+  /// 播放器内核
+  videoKennel,
+  /// 是否开启成人模式
   isNsfw,
+  /// 当前源(索引)
   mirrorIndex,
+  /// 源链接(textarea)
   mirrorTextarea,
+  /// 是否已经提示过免责声明
   showPlayTips,
+  /// webview 启动的服务类型
   webviewPlayType,
+  /// 首次启动
   onBoardingShowed,
 }
 

--- a/lib/shared/manage.dart
+++ b/lib/shared/manage.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:isar/isar.dart';
 import 'package:catmovie/app/extension.dart';
 import 'package:catmovie/builtin/maccms/maccms.dart';
-import 'package:xi/adapters/mac_cms.dart';
 import 'package:xi/xi.dart';
 import 'package:catmovie/isar/repo.dart';
 import 'package:catmovie/isar/schema/mirror_schema.dart';

--- a/packages/xi/lib/utils/source.dart
+++ b/packages/xi/lib/utils/source.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:xi/adapters/mac_cms.dart';
 import 'package:xi/xi.dart';
 import 'package:xi/models/mac_cms/source_data.dart';
 

--- a/packages/xi/lib/xi.dart
+++ b/packages/xi/lib/xi.dart
@@ -6,3 +6,5 @@ export 'package:jsonc/jsonc.dart';
 export 'interface.dart';
 export 'utils/utils.dart';
 export 'models/models.dart';
+
+export 'adapters/mac_cms.dart';

--- a/script/add_builtin.dart
+++ b/script/add_builtin.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print, depend_on_referenced_packages
+
 import 'dart:convert';
 import 'dart:io';
 import 'package:http/http.dart' as http;
@@ -57,7 +59,7 @@ String space(int size) {
 }
 
 String toDartCode(List<X> sources) {
-  String result = '''import 'package:xi/adapters/mac_cms.dart';\n
+  String result = '''import 'package:xi/xi.dart';\n
 var list\$ = [\n''';
   for (var source in sources) {
     result += '${space(2)}MacCMSSpider(\n';


### PR DESCRIPTION
在这个PR中, 我引入了一个播放器内核的概念(默认是 WebView)

- WebView
  - Desktop: 使用 [desktop_webview_window](https://github.com/MixinNetwork/flutter-plugins) 创建新窗口逻辑
  - Android: TOOOOOOOOODO(别担心, 后续会优化的)
     - Iframe: WebViewView()
     - M3u8/Mp4: ChewieView()
  - iOS: 将真实播放链接丢给浏览器
- MediaKit: 内嵌到视频详情页里
- IINA: macOS only

在这之后, 我们就可以理所当然的将这两个设置项给删掉了

```diff
- iosCanBeUseSystemBrowser
- macosPlayUseIINA
```

需要注意的是, 在 MediaKit 内核中, Iframe 链接无法播放, 这个别担心, 留在下一个PR解决这个