### PR TITLE
Patch: support parse iframe video-links

### DIFF
--- a/lib/app/modules/play/controllers/play_controller.dart
+++ b/lib/app/modules/play/controllers/play_controller.dart
@@ -413,16 +413,29 @@ document.addEventListener('DOMContentLoaded', function() {
           return false;
         }
         if (curr.type == VideoType.iframe) {
-          EasyLoading.showError("IINA不支持iframe播放");
-          return false;
-        } else {
-          url.openToIINA();
+          var closed = showLoading("正在解析iframe");
+          var result = await home.currentMirrorItem.parseIframe(url);
+          closed();
+          if (result.isEmpty) {
+            EasyLoading.showError("解析失败, 无法播放");
+            return false;
+          }
+          debugPrint("result: $result");
+          url = result[0]; // NOTE(d1y): 估计解析到不止一个, 该用哪一个呢!
         }
+        url.openToIINA();
         break;
       case VideoKernel.mediaKit:
         if (curr.type == VideoType.iframe) {
-          EasyLoading.showError("Media-Kit不支持iframe播放");
-          return false;
+          var closed = showLoading("正在解析iframe");
+          var result = await home.currentMirrorItem.parseIframe(url);
+          closed();
+          if (result.isEmpty) {
+            EasyLoading.showError("解析失败, 无法播放");
+            return false;
+          }
+          debugPrint("result: $result");
+          url = result[0]; // NOTE(d1y): 估计解析到不止一个, 该用哪一个呢!
         }
         mediaKitPlayer.open(Media(url));
         break;

--- a/lib/app/modules/play/controllers/play_controller.dart
+++ b/lib/app/modules/play/controllers/play_controller.dart
@@ -333,6 +333,19 @@ document.addEventListener('DOMContentLoaded', function() {
     return true;
   }
 
+  Future<String> parseIframe(String iframe) async {
+    var closed = showLoading("正在解析iframe");
+    var result = await home.currentMirrorItem.parseIframe(iframe);
+    closed();
+    if (result.isEmpty) {
+      EasyLoading.showError("解析失败, 无法播放");
+      return "";
+    }
+    debugPrint("result: $result");
+    String url = result[0]; // NOTE(d1y): 估计解析到不止一个, 该用哪一个呢!
+    return url;
+  }
+
   Future<bool> handleTapPlayerButtom(
     VideoInfo curr,
     List<VideoInfo> playList,
@@ -403,6 +416,10 @@ document.addEventListener('DOMContentLoaded', function() {
               );
             }
           } else {
+            if (curr.type == VideoType.iframe) {
+              url = await parseIframe(url);
+              if (url.isEmpty) return false;
+            }
             url.openURL();
           }
         }
@@ -413,29 +430,15 @@ document.addEventListener('DOMContentLoaded', function() {
           return false;
         }
         if (curr.type == VideoType.iframe) {
-          var closed = showLoading("正在解析iframe");
-          var result = await home.currentMirrorItem.parseIframe(url);
-          closed();
-          if (result.isEmpty) {
-            EasyLoading.showError("解析失败, 无法播放");
-            return false;
-          }
-          debugPrint("result: $result");
-          url = result[0]; // NOTE(d1y): 估计解析到不止一个, 该用哪一个呢!
+          url = await parseIframe(url);
+          if (url.isEmpty) return false;
         }
         url.openToIINA();
         break;
       case VideoKernel.mediaKit:
         if (curr.type == VideoType.iframe) {
-          var closed = showLoading("正在解析iframe");
-          var result = await home.currentMirrorItem.parseIframe(url);
-          closed();
-          if (result.isEmpty) {
-            EasyLoading.showError("解析失败, 无法播放");
-            return false;
-          }
-          debugPrint("result: $result");
-          url = result[0]; // NOTE(d1y): 估计解析到不止一个, 该用哪一个呢!
+          url = await parseIframe(url);
+          if (url.isEmpty) return false;
         }
         mediaKitPlayer.open(Media(url));
         break;

--- a/packages/xi/lib/adapters/mac_cms.dart
+++ b/packages/xi/lib/adapters/mac_cms.dart
@@ -11,6 +11,9 @@ import '../models/mac_cms/xml_search_data.dart';
 import 'package:xml2json/xml2json.dart';
 import 'package:path/path.dart' as path;
 
+/// m3u8 | mp4 都会抓取到
+final kIframeParseRegex = RegExp("[\"']([^\"']+.(m3u8|mp4))[\"']");
+
 /// 请求返回的内容
 enum ResponseCustomType {
   xml,
@@ -479,5 +482,36 @@ class MacCMSSpider extends ISpiderAdapter {
     output += "name: $name\n";
     output += " url: $root_url$api_path";
     return output;
+  }
+
+  List<String> _parseIframe(String iframe,String body) {
+    var url = Uri.tryParse(iframe);
+    if (url == null) return [];
+    var domain = "${url.scheme}://${url.host}";
+    final List<String> m3u8Links = [];
+    for (final Match match in kIframeParseRegex.allMatches(body)) {
+      if (match.groupCount >= 1) {
+        String? link = match.group(1);
+        if (link != null && link.isNotEmpty) {
+          if (!(link.startsWith("http://") || link.startsWith("https://"))) {
+            link = "$domain$link"; /// 如果 $link 前缀不是 /xx/xx.m3u8 那就惨了!
+          }
+          m3u8Links.add(link);
+        }
+      }
+    }
+    return m3u8Links;
+  }
+
+  @override
+  // TODO(d1y): 这个应该交由原配置去解析, 这里的通用解析只是为了乐呵乐呵(某些估计解析不了?)
+  Future<List<String>> parseIframe(String iframe) async {
+    try {
+      var resp = await XHttp.dio.get<String>(iframe);
+      var htmlText = resp.data ?? "";
+      return _parseIframe(iframe, htmlText);
+    } catch (e) {
+      return []; // catch error
+    }
   }
 }

--- a/packages/xi/lib/interface.dart
+++ b/packages/xi/lib/interface.dart
@@ -202,6 +202,9 @@ abstract class ISpiderAdapter {
 
   /// 获取视频详情
   Future<VideoDetail> getDetail(String movieId);
+
+  /// 解析 iframe 链接
+  Future<List<String>> parseIframe(String iframe);
 }
 
 /// 基本上它就是一个空的占位符
@@ -225,6 +228,11 @@ class EmptySpiderAdapter implements ISpiderAdapter {
   @override
   Future<List<VideoDetail>> getSearch(
       {required String keyword, int page = 1, int limit = 10}) async {
+    return [];
+  }
+
+  @override
+  Future<List<String>> parseIframe(String iframe) async {
     return [];
   }
 


### PR DESCRIPTION
#111 的后续
这个PR我想支持解析 iframe 以便喂给 media-kit 真实链接
👇🏻👇🏻下面👇🏻👇🏻文档, 通过解析可以获得

- https://x.com/2.m3u8
- /3.mp4
- /4.m3u8

> 这里的 3.mp4 和 4.m3u8 会拼接自己的 iframe 嵌套域名

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>Hello</title>
  <script>

    const xxxxxxxxxxx = "这不重要";

    const sbObj = {
      url: "https://x.com/2.m3u8",
      url1: "/3.mp4",
      url3: '/4.m3u8'
    }
  </script>
</head>
<body>
  <video id="sb"></video>
</body>
</html>
```

## Next

**这只是一个临时解决办法, 实际上我希望它能够在单源配置中(配置)添加这个字段, 使其自定义解析**