### PR TITLE
Fix: iOS enter fullscreen will pause

### DIFF
--- a/lib/app/modules/play/views/play_view.dart
+++ b/lib/app/modules/play/views/play_view.dart
@@ -175,6 +175,27 @@ class _PlayViewState extends State<PlayView> with AfterLayoutMixin {
         // TODO(d1y): support dynamic set box-fit
         fit: BoxFit.cover,
         controller: controller,
+        onEnterFullscreen: () async {
+          await defaultEnterNativeFullscreen();
+          // workaround: 在 iOS 上全屏之后播放会暂停
+          if (GetPlatform.isIOS) {
+            Future.delayed(const Duration(milliseconds: 88), () {
+              controller.player.pause();
+              controller.player.play();
+            });
+          }
+        },
+        onExitFullscreen: () async {
+          await defaultExitNativeFullscreen();
+          if (GetPlatform.isMobile) {
+            SystemChrome.setPreferredOrientations(
+              [
+                DeviceOrientation.portraitUp,
+                DeviceOrientation.portraitDown,
+              ],
+            );
+          }
+        },
       ),
     );
   }


### PR DESCRIPTION
在iOS上，当全屏之后会自动暂停播放(https://github.com/media-kit/media-kit/issues/935#issuecomment-3015381655)
在上游似乎也没有找到解决办法, 所以只能临时先 `pause` -> `play()` 这样