### PR TITLE
Fix: mediakit gesture abnormal

### DIFF
--- a/lib/app/modules/play/views/play_view.dart
+++ b/lib/app/modules/play/views/play_view.dart
@@ -245,37 +245,39 @@ class _PlayViewState extends State<PlayView> with AfterLayoutMixin {
   }
 
   Widget _buildCoverImage() {
-    return Positioned.fill(
-      child: Stack(
-        children: [
-          Positioned.fill(
-            child: ClipRect(
-              child: Stack(
-                children: [
-                  Positioned.fill(
-                    child: CachedNetworkImage(
-                      imageUrl: play.movieItem.smallCoverImage,
-                      fit: BoxFit.cover,
+    return IgnorePointer(
+      child: Positioned.fill(
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: ClipRect(
+                child: Stack(
+                  children: [
+                    Positioned.fill(
+                      child: CachedNetworkImage(
+                        imageUrl: play.movieItem.smallCoverImage,
+                        fit: BoxFit.cover,
+                      ),
                     ),
-                  ),
-                  Positioned.fill(
-                    child: BackdropFilter(
-                      filter: ImageFilter.blur(sigmaX: 24, sigmaY: 24),
-                      child:
-                          Container(color: Colors.white.withValues(alpha: .12)),
+                    Positioned.fill(
+                      child: BackdropFilter(
+                        filter: ImageFilter.blur(sigmaX: 24, sigmaY: 24),
+                        child:
+                            Container(color: Colors.white.withValues(alpha: .12)),
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
-          ),
-          Positioned.fill(
-            child: CachedNetworkImage(
-              imageUrl: play.movieItem.smallCoverImage,
-              fit: BoxFit.contain,
-            ),
-          )
-        ],
+            Positioned.fill(
+              child: CachedNetworkImage(
+                imageUrl: play.movieItem.smallCoverImage,
+                fit: BoxFit.contain,
+              ),
+            )
+          ],
+        ),
       ),
     );
   }

--- a/lib/app/modules/play/views/play_view.dart
+++ b/lib/app/modules/play/views/play_view.dart
@@ -411,8 +411,6 @@ class _PlayViewState extends State<PlayView> with AfterLayoutMixin {
             vertical: 24,
             horizontal: 12,
           ),
-          brightnessGesture: true,
-          volumeGesture: true,
           seekGesture: true,
           seekOnDoubleTap: true,
           speedUpOnLongPress: true,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -892,7 +892,7 @@ packages:
     description:
       path: media_kit_video
       ref: main
-      resolved-ref: "1906ba6799f3c43d80747ed42927e1eb7d898306"
+      resolved-ref: "885cfa45e62b8ad1778ee8dc61ca7a48a96e0e27"
       url: "https://github.com/waifu-project/media-kit.git"
     source: git
     version: "1.2.5"


### PR DESCRIPTION
在这个PR中我修复了两个已知的MediaKit内核的Bug

- 在某处点击无法显示 control (https://github.com/waifu-project/media-kit/commit/21b71e64ef7b09659cb26c5f0721245e0d68054f)
- 点击事件和长按事件冲突 (https://github.com/waifu-project/media-kit/commit/885cfa45e62b8ad1778ee8dc61ca7a48a96e0e27)