### PR TITLE
Patch: disable PullDown

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -38,7 +38,7 @@ PODS:
     - Flutter
   - haptic_feedback (0.5.1):
     - Flutter
-  - isar_flutter_libs (1.0.0):
+  - isar_community_flutter_libs (1.0.0):
     - Flutter
   - media_kit_libs_ios_video (1.0.4):
     - Flutter
@@ -80,7 +80,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - haptic_feedback (from `.symlinks/plugins/haptic_feedback/ios`)
-  - isar_flutter_libs (from `.symlinks/plugins/isar_flutter_libs/ios`)
+  - isar_community_flutter_libs (from `.symlinks/plugins/isar_community_flutter_libs/ios`)
   - media_kit_libs_ios_video (from `.symlinks/plugins/media_kit_libs_ios_video/ios`)
   - media_kit_video (from `.symlinks/plugins/media_kit_video/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -111,8 +111,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   haptic_feedback:
     :path: ".symlinks/plugins/haptic_feedback/ios"
-  isar_flutter_libs:
-    :path: ".symlinks/plugins/isar_flutter_libs/ios"
+  isar_community_flutter_libs:
+    :path: ".symlinks/plugins/isar_community_flutter_libs/ios"
   media_kit_libs_ios_video:
     :path: ".symlinks/plugins/media_kit_libs_ios_video/ios"
   media_kit_video:
@@ -147,7 +147,7 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_keyboard_visibility: 4625131e43015dbbe759d9b20daaf77e0e3f6619
   haptic_feedback: fd1d8509833f58f164fc12122c0357fa9b2750e0
-  isar_flutter_libs: bc909e72c3d756c2759f14c8776c13b5b0556e26
+  isar_community_flutter_libs: bede843185a61a05ff364a05c9b23209523f7e0d
   media_kit_libs_ios_video: 5a18affdb97d1f5d466dc79988b13eff6c5e2854
   media_kit_video: 1746e198cb697d1ffb734b1d05ec429d1fcd1474
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499

--- a/lib/app/modules/home/controllers/home_controller.dart
+++ b/lib/app/modules/home/controllers/home_controller.dart
@@ -38,10 +38,12 @@ enum UpdateSearchHistoryType {
 }
 
 Widget kActivityIndicator = NutsActivityIndicator(
-      tickCount: 12,
-      radius: 12,
-      relativeWidth: .72,
-    );
+  tickCount: 9,
+  radius: 12,
+  relativeWidth: 1.24,
+  inactiveColor: Colors.white.withValues(alpha: 0.42),
+  activeColor: Colors.white,
+);
 
 Function showLoading(String msg) {
   EasyLoading.show(

--- a/lib/app/modules/home/views/index_home_view.dart
+++ b/lib/app/modules/home/views/index_home_view.dart
@@ -356,155 +356,164 @@ class _IndexHomeViewState extends State<IndexHomeView>
                             context: context,
                           );
                         }
-                        return SmartRefresher(
-                          enablePullDown: indexEnablePullDown,
-                          enablePullUp: indexEnablePullUp,
-                          header: const WaterDropHeader(
-                            refresh: Row(
-                              spacing: 12,
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                CupertinoActivityIndicator(),
-                                Text("加载中"),
-                              ],
-                            ),
-                            complete: Row(
-                              spacing: 12,
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Icon(CupertinoIcons.smiley),
-                                Text("加载完成"),
-                              ],
-                            ),
+                        return RefreshConfiguration(
+                          springDescription: const SpringDescription(
+                            mass: 1,
+                            stiffness: 364.71867768595047,
+                            damping: 35.2,
                           ),
-                          footer: CustomFooter(
-                            builder: (BuildContext context, LoadStatus? mode) {
-                              Widget body;
-                              if (mode == LoadStatus.idle) {
-                                body = const Text("上划加载更多");
-                              } else if (mode == LoadStatus.loading) {
-                                body = const CupertinoActivityIndicator();
-                              } else if (mode == LoadStatus.failed) {
-                                body = const Text("加载失败, 请重试");
-                              } else if (mode == LoadStatus.canLoading) {
-                                body = const Text("释放以加载更多");
-                              } else {
-                                body = const Text("没有更多数据");
-                              }
-                              return Center(
-                                child: body,
-                              );
-                            },
-                          ),
-                          scrollController: scrollController,
-                          controller: homeview.refreshController,
-                          onLoading: homeview.refreshOnLoading,
-                          onRefresh: homeview.refreshOnRefresh,
-                          child: Builder(
-                            builder: (_) {
-                              if (homeview.isLoading) {
-                                return const SizedBox.shrink();
-                              }
-                              if (homeview.homedata.isEmpty) {
-                                if (errorMsg.isNotEmpty) {
-                                  return SizedBox(
-                                    width: double.infinity,
-                                    height: double.infinity,
-                                    child: Column(
-                                      children: [
-                                        SizedBox(height: 42),
-                                        Center(
-                                          child: Column(
-                                            mainAxisSize: MainAxisSize.min,
-                                            spacing: 12,
-                                            children: [
-                                              Image.asset(
-                                                "assets/images/error.png",
-                                                width: 120,
-                                                height: 120,
-                                              ),
-                                              Zoom(
-                                                child: CupertinoButton.filled(
-                                                  padding: const EdgeInsets
-                                                      .symmetric(
-                                                    vertical: 12.0,
-                                                    horizontal: 24.0,
-                                                  ),
-                                                  onPressed: () {
-                                                    boop.selection();
-                                                    homeview.updateHomeData(
-                                                        isFirst: true);
-                                                  },
-                                                  child: const Text(
-                                                    "重新加载",
-                                                    style: TextStyle(
-                                                      fontSize: 12,
+                          child: SmartRefresher(
+                            header: const WaterDropHeader(
+                              refresh: Row(
+                                spacing: 12,
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  CupertinoActivityIndicator(),
+                                  Text("加载中"),
+                                ],
+                              ),
+                              complete: Row(
+                                spacing: 12,
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Icon(CupertinoIcons.smiley),
+                                  Text("加载完成"),
+                                ],
+                              ),
+                            ),
+                            footer: CustomFooter(
+                              builder:
+                                  (BuildContext context, LoadStatus? mode) {
+                                Widget body;
+                                if (mode == LoadStatus.idle) {
+                                  body = const Text("上划加载更多");
+                                } else if (mode == LoadStatus.loading) {
+                                  body = const CupertinoActivityIndicator();
+                                } else if (mode == LoadStatus.failed) {
+                                  body = const Text("加载失败, 请重试");
+                                } else if (mode == LoadStatus.canLoading) {
+                                  body = const Text("释放以加载更多");
+                                } else {
+                                  body = const Text("没有更多数据");
+                                }
+                                return Center(child: body);
+                              },
+                            ),
+                            enablePullDown: indexEnablePullDown,
+                            enablePullUp: indexEnablePullUp,
+                            scrollController: scrollController,
+                            physics: const BouncingScrollPhysics(),
+                            controller: homeview.refreshController,
+                            onLoading: homeview.refreshOnLoading,
+                            onRefresh: homeview.refreshOnRefresh,
+                            child: Builder(
+                              builder: (_) {
+                                if (homeview.isLoading) {
+                                  return const SizedBox.shrink();
+                                }
+                                if (homeview.homedata.isEmpty) {
+                                  if (errorMsg.isNotEmpty) {
+                                    return SizedBox(
+                                      width: double.infinity,
+                                      height: double.infinity,
+                                      child: Column(
+                                        children: [
+                                          SizedBox(height: 42),
+                                          Center(
+                                            child: Column(
+                                              mainAxisSize: MainAxisSize.min,
+                                              spacing: 12,
+                                              children: [
+                                                Image.asset(
+                                                  "assets/images/error.png",
+                                                  width: 120,
+                                                  height: 120,
+                                                ),
+                                                Zoom(
+                                                  child: CupertinoButton.filled(
+                                                    padding: const EdgeInsets
+                                                        .symmetric(
+                                                      vertical: 12.0,
+                                                      horizontal: 24.0,
+                                                    ),
+                                                    onPressed: () {
+                                                      boop.selection();
+                                                      homeview.updateHomeData(
+                                                          isFirst: true);
+                                                    },
+                                                    child: const Text(
+                                                      "重新加载",
+                                                      style: TextStyle(
+                                                        fontSize: 12,
+                                                      ),
                                                     ),
                                                   ),
                                                 ),
-                                              ),
-                                            ],
+                                              ],
+                                            ),
                                           ),
-                                        ),
-                                        SizedBox(
-                                          width: double.infinity,
-                                          height:
-                                              context.mediaQuery.size.height *
-                                                  .42,
-                                          child: KErrorStack(msg: errorMsg),
-                                        ),
-                                      ],
-                                    ),
+                                          SizedBox(
+                                            width: double.infinity,
+                                            height:
+                                                context.mediaQuery.size.height *
+                                                    .42,
+                                            child: KErrorStack(msg: errorMsg),
+                                          ),
+                                        ],
+                                      ),
+                                    );
+                                  }
+                                  return Column(
+                                    spacing: 12,
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      SizedBox(height: 42),
+                                      Image.asset(
+                                        "assets/images/error.png",
+                                        width: 120,
+                                        height: 120,
+                                      ),
+                                      Text("当前请求列表为空",
+                                          style: TextStyle(
+                                            color: (context.isDarkMode
+                                                    ? '#6f737a'
+                                                    : '#767a82')
+                                                .$color,
+                                          )),
+                                      SizedBox(height: 88),
+                                    ],
                                   );
                                 }
-                                return Column(
-                                  spacing: 12,
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    SizedBox(height: 42),
-                                    Image.asset(
-                                      "assets/images/error.png",
-                                      width: 120,
-                                      height: 120,
-                                    ),
-                                    Text("当前请求列表为空",
-                                        style: TextStyle(
-                                          color: (context.isDarkMode
-                                                  ? '#6f737a'
-                                                  : '#767a82')
-                                              .$color,
-                                        )),
-                                    SizedBox(height: 88),
-                                  ],
+                                return GridView.builder(
+                                  physics: const NeverScrollableScrollPhysics(),
+                                  shrinkWrap: true,
+                                  gridDelegate:
+                                      SliverGridDelegateWithFixedCrossAxisCount(
+                                    crossAxisCount: cardCount,
+                                    crossAxisSpacing: kHomeMovieCardSpacing,
+                                    mainAxisSpacing: kHomeMovieCardSpacing,
+                                    childAspectRatio: 12 / 9,
+                                  ),
+                                  itemCount: homeview.homedata.length,
+                                  itemBuilder: (
+                                    BuildContext context,
+                                    int index,
+                                  ) {
+                                    var subItem = homeview.homedata[index];
+                                    return MovieCardItem(
+                                      imageUrl: subItem.smallCoverImage,
+                                      title: subItem.title,
+                                      note: subItem.remark,
+                                      onTap: () {
+                                        EasyLoading.dismiss();
+                                        handleClickItem(subItem, controller);
+                                        boop.selection();
+                                      },
+                                    );
+                                  },
                                 );
-                              }
-                              return GridView.builder(
-                                controller: ScrollController(),
-                                physics: const NeverScrollableScrollPhysics(),
-                                shrinkWrap: true,
-                                gridDelegate:
-                                    SliverGridDelegateWithFixedCrossAxisCount(
-                                  crossAxisCount: cardCount,
-                                  crossAxisSpacing: kHomeMovieCardSpacing,
-                                  mainAxisSpacing: kHomeMovieCardSpacing,
-                                  childAspectRatio: 12 / 9,
-                                ),
-                                itemCount: homeview.homedata.length,
-                                itemBuilder: (BuildContext context, int index) {
-                                  var subItem = homeview.homedata[index];
-                                  return MovieCardItem(
-                                    imageUrl: subItem.smallCoverImage,
-                                    title: subItem.title,
-                                    note: subItem.remark,
-                                    onTap: () {
-                                      EasyLoading.dismiss();
-                                      handleClickItem(subItem, controller);
-                                      boop.selection();
-                                    },
-                                  );
-                                },
-                              );
-                            },
+                              },
+                            ),
                           ),
                         );
                       }),

--- a/lib/app/modules/home/views/index_home_view.dart
+++ b/lib/app/modules/home/views/index_home_view.dart
@@ -91,7 +91,7 @@ class _IndexHomeViewState extends State<IndexHomeView>
   }
 
   bool get indexEnablePullDown {
-    return !controller.isLoading;
+    return !controller.isLoading && false;
   }
 
   bool get indexEnablePullUp {

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -119,7 +119,7 @@ SPEC CHECKSUMS:
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
   video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b
-  wakelock_plus: 21ddc249ac4b8d018838dbdabd65c5976c308497
+  wakelock_plus: 917609be14d812ddd9e9528876538b2263aaa03b
   webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
   window_manager: b729e31d38fb04905235df9ea896128991cad99e
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -190,10 +190,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: ba95c961bafcd8686d1cf63be864eb59447e795e124d98d6a27d91fcd13602fb
+      sha256: a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d
       url: "https://pub.dev"
     source: hosted
-    version: "8.11.1"
+    version: "8.12.0"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -246,10 +246,10 @@ packages:
     dependency: "direct main"
     description:
       name: chewie
-      sha256: "19b93a1e60e4ba640a792208a6543f1c7d5b124d011ce0199e2f18802199d984"
+      sha256: "44bcfc5f0dfd1de290c87c9d86a61308b3282a70b63435d5557cfd60f54a69ca"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.13.0"
   chinese_font_library:
     dependency: "direct main"
     description:
@@ -278,10 +278,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.1"
+    version: "4.11.0"
   collection:
     dependency: "direct main"
     description:
@@ -496,10 +496,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: ef7d2a085c1b1d69d17b6842d0734aad90156de08df6bd3c12496d0bd6ddf8e2
+      sha256: f2d9f173c2c14635cc0e9b14c143c49ef30b4934e8d1d274d6206fcb0086a06f
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.1"
+    version: "10.3.3"
   fixnum:
     dependency: transitive
     description:
@@ -606,18 +606,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "6382ce712ff69b0f719640ce957559dde459e55ecd433c767e06d139ddf16cab"
+      sha256: b0694b7fb1689b0e6cc193b3f1fcac6423c4f93c74fb20b806c6b6f196db0c31
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.29"
+    version: "2.0.30"
   flutter_slidable:
     dependency: "direct main"
     description:
       name: flutter_slidable
-      sha256: ab7dbb16f783307c9d7762ede2593ce32c220ba2ba0fd540a3db8e9a3acba71a
+      sha256: e6bd17290cf0d011f9ed66c74d4159b8fe3b3050afedac0f11fab1ba8687e710
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   flutter_spinkit:
     dependency: transitive
     description:
@@ -756,10 +756,10 @@ packages:
     dependency: "direct dev"
     description:
       name: icons_launcher
-      sha256: "2949eef3d336028d89133f69ef221d877e09deed04ebd8e738ab4a427850a7a2"
+      sha256: e6d806458fac6d3b1126ad757b4208a314ba775b3c8119cd88877091379edc7a
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   image:
     dependency: transitive
     description:
@@ -1004,10 +1004,10 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.1"
+    version: "9.0.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1044,18 +1044,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.17"
+    version: "2.2.18"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1084,10 +1084,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.0.1"
   platform:
     dependency: transitive
     description:
@@ -1172,10 +1172,10 @@ packages:
     dependency: "direct main"
     description:
       name: provider
-      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "6.1.5+1"
   pub_semver:
     dependency: transitive
     description:
@@ -1236,10 +1236,10 @@ packages:
     dependency: transitive
     description:
       name: screen_brightness_android
-      sha256: fb5fa43cb89d0c9b8534556c427db1e97e46594ac5d66ebdcf16063b773d54ed
+      sha256: d34f5321abd03bc3474f4c381f53d189117eba0b039eac1916aa92cca5fd0a96
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   screen_brightness_ios:
     dependency: transitive
     description:
@@ -1316,10 +1316,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1
+      sha256: "3424e9d5c22fd7f7590254ba09465febd6f8827c8b19a44350de4ac31d92d3a6"
       url: "https://pub.dev"
     source: hosted
-    version: "11.1.0"
+    version: "12.0.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1348,10 +1348,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   simple:
     dependency: "direct main"
     description:
@@ -1409,10 +1409,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_android
-      sha256: "2b3070c5fa881839f8b402ee4a39c1b4d561704d4ebbbcfb808a119bc2a1701b"
+      sha256: ecd684501ebc2ae9a83536e8b15731642b9570dc8623e0073d227d0ee2bfea88
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2+2"
   sqflite_common:
     dependency: transitive
     description:
@@ -1569,18 +1569,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "0aedad096a85b49df2e4725fa32118f9fa580f3b14af7a2d2221896a02cd5656"
+      sha256: "199bc33e746088546a39cc5f36bac5a278c5e53b40cb3196f99e7345fdcfae6b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.17"
+    version: "6.3.22"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      sha256: d80b3f567a617cb923546034cc94bfe44eb15f989fe670b37f26abdb9d939cb7
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "6.3.4"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -1593,10 +1593,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      sha256: c043a77d6600ac9c38300567f33ef12b0ef4f4783a2c1f00231d2b1941fea13f
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1681,10 +1681,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: d26f8791c8f670825cc227e2cad4319d2ac02b71b2ad5c2b67786bb873ac43b1
+      sha256: "59e5a457ddcc1688f39e9aef0efb62aa845cf0cbbac47e44ac9730dc079a2385"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.11"
+    version: "2.8.13"
   video_player_avfoundation:
     dependency: transitive
     description:
@@ -1729,26 +1729,26 @@ packages:
     dependency: "direct main"
     description:
       name: wakelock_plus
-      sha256: a474e314c3e8fb5adef1f9ae2d247e57467ad557fa7483a2b895bc1b421c5678
+      sha256: "9296d40c9adbedaba95d1e704f4e0b434be446e2792948d0e4aa977048104228"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   wakelock_plus_platform_interface:
     dependency: transitive
     description:
       name: wakelock_plus_platform_interface
-      sha256: e10444072e50dbc4999d7316fd303f7ea53d31c824aa5eb05d7ccbdd98985207
+      sha256: "036deb14cd62f558ca3b73006d52ce049fabcdcb2eddfe0bf0fe4e8a943b5cf2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
+      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   web:
     dependency: transitive
     description:
@@ -1794,10 +1794,10 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: "414174cacd339046a1a6dbf93cac62422194c676fed11119ccf228b81640e887"
+      sha256: "3c4eb4fcc252b40c2b5ce7be20d0481428b70f3ff589b0a8b8aaeb64c6bed701"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.1"
+    version: "4.10.2"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
@@ -1865,10 +1865,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.6.1"
   xml2json:
     dependency: transitive
     description:
@@ -1894,5 +1894,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.29.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   settings_ui: ^2.0.2
 
   file_picker: ^10.2.0
-  share_plus: ^11.0.0
+  share_plus: ^12.0.0
 
   equatable: ^2.0.7
 


### PR DESCRIPTION
现在首页第一次加载列表之后, 触发一次下拉就会无法再次滚动

这似乎是因为 https://github.com/flutter/flutter/pull/165017 的改动造成的

> 迁移指南: [here](https://docs.flutter.dev/release/breaking-changes/spring-description-underdamped#default-constructor)

迁移之后的弹性动画:

```dart
SpringDescription(
  mass: 1,
  stiffness: 364.71867768595047,
  damping: 35.2,
)
```

但是现在改完之后, 其实还是有问题, 观察到的现象似乎会在(第二次)下拉之后, 0.5秒之后才能重新恢复滚动操作, 在这期间无法滚动操作

**所以, 先暂时禁用下拉吧**

> 等待上游修复, 再恢复吧

参考:

- https://github.com/peng8350/flutter_pulltorefresh/issues/656
- https://github.com/peng8350/flutter_pulltorefresh/issues/658